### PR TITLE
perf: skip the scheduler if an async operation is already complete.

### DIFF
--- a/include/cask/Deferred.hpp
+++ b/include/cask/Deferred.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include "Promise.hpp"
 #include <exception>
+#include <optional>
 
 namespace cask {
 
@@ -142,6 +143,8 @@ public:
      * @return The result value of the asynchronous computation.
      */
     virtual T await() = 0;
+
+    virtual std::optional<Either<T,E>> get() = 0;
 
     virtual ~Deferred() {};
 };

--- a/include/cask/deferred/PromiseDeferred.hpp
+++ b/include/cask/deferred/PromiseDeferred.hpp
@@ -31,6 +31,7 @@ public:
     void onCancel(std::function<void()> callback) override;
     void cancel() override;
     T await() override;
+    std::optional<Either<T,E>> get() override;
 
     std::shared_ptr<Promise<T,E>> promise;
 private:
@@ -105,6 +106,11 @@ T PromiseDeferred<T,E>::await() {
     } else {
         throw result->get_right();
     }
+}
+
+template <class T, class E>
+std::optional<Either<T,E>> PromiseDeferred<T,E>::get() {
+    return promise->get();
 }
 
 }

--- a/include/cask/deferred/PureDeferred.hpp
+++ b/include/cask/deferred/PureDeferred.hpp
@@ -24,6 +24,7 @@ public:
     void onCancel(std::function<void()> callback) override;
     void cancel() override;
     T await() override;
+    std::optional<Either<T,E>> get() override;
 private:
 };
 
@@ -65,6 +66,11 @@ void PureDeferred<T,E>::cancel() {
 template <class T, class E>
 T PureDeferred<T,E>::await() {
     return value;
+}
+
+template <class T, class E>
+std::optional<Either<T,E>> PureDeferred<T,E>::get() {
+    return Either<T,E>::left(value);
 }
 
 }

--- a/include/cask/deferred/PureErrorDeferred.hpp
+++ b/include/cask/deferred/PureErrorDeferred.hpp
@@ -22,6 +22,7 @@ public:
     void onCancel(std::function<void()> callback) override;
     void cancel() override;
     T await() override;
+    std::optional<Either<T,E>> get() override;
 };
 
 template <class T, class E>
@@ -57,6 +58,11 @@ void PureErrorDeferred<T,E>::cancel() {
 template <class T, class E>
 T PureErrorDeferred<T,E>::await() {
     throw error;
+}
+
+template <class T, class E>
+std::optional<Either<T,E>> PureErrorDeferred<T,E>::get() {
+    throw Either<T,E>::right(error);
 }
 
 }


### PR DESCRIPTION
This is a quick "fix" to try and avoid the scheduler entirely in cases where the deferred portion of an async operation has already completed. This initial fix is a bit of a hack - but I'm putting it out there to try and get feedback on if it helps things.