### PR TITLE
chore: remove codecov due to security breach

### DIFF
--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -43,12 +43,6 @@ jobs:
     - name: Generate Coverage Reports
       if: ${{ matrix.target == 'debug' }}
       run: ninja coverage -C build_${{ matrix.target }}
-    - name: Upload Coverage Results to Codecov
-      if: ${{ matrix.target == 'debug' }}
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
   
   build-mac:
     name: Mac Build and Test


### PR DESCRIPTION
We've gotten an email that codecov has been breached. I'm pulling uploads until I get a better idea of what's going on.