### PR TITLE
fix: defer calling release until it is actually needed.

### DIFF
--- a/include/cask/Resource.hpp
+++ b/include/cask/Resource.hpp
@@ -91,7 +91,11 @@ template <class T, class E>
 constexpr Resource<T,E> Resource<T,E>::make(const Task<T,E> &acquire, ReleaseFunction release) noexcept {
     return Resource<T,E>(
         acquire.template map<AllocatedResource>([release](T thing) {
-            return std::tuple<T,ReleaseTask>(thing, release(thing));
+            auto deferredRelease = ReleaseTask::defer([thing, release] {
+                return release(thing);
+            });
+
+            return std::tuple<T,ReleaseTask>(thing, deferredRelease);
         })
     );
 }


### PR DESCRIPTION
This change resolves an issue where the release function would be unexpectedly called _before_ usage rather than after. This call was to obtain a pure task representing the releasing - but in reality it forced the burden on properly deferring any execution onto callers and was overall a surprising behavior. To resolve this calling the release function is always deferred in a way that guarantees is is only called when release actually happens.