### PR TITLE
fix: make takewhile properly run downstream completion and error tasks.

### DIFF
--- a/include/cask/observable/TakeWhileObserver.hpp
+++ b/include/cask/observable/TakeWhileObserver.hpp
@@ -70,19 +70,19 @@ Task<Ack,None> TakeWhileObserver<T,E>::onNext(const T& value) {
 template <class T, class E>
 Task<None,None> TakeWhileObserver<T,E>::onError(const E& error) {
     if(!completed.test_and_set()) {
-        downstream->onError(error);
+        return downstream->onError(error);
+    } else {
+        return Task<None,None>::none();
     }
-
-    return Task<None,None>::none();
 }
 
 template <class T, class E>
 Task<None,None> TakeWhileObserver<T,E>::onComplete() {
     if(!completed.test_and_set()) {
-        downstream->onComplete();
+        return downstream->onComplete();
+    } else {
+        return Task<None,None>::none();
     }
-
-    return Task<None,None>::none();
 }
 
 }


### PR DESCRIPTION
This change resolves an issue where `takeWhile` and `takeWhileInclusive` were not properly returning the downstream completion and error tasks. This meant those handlers, if they were composed of real tasks that needed running, where not being executed properly.