### PR TITLE
fix: provide better sleeping behavior for similiar throughput.

### DIFF
--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -52,6 +52,8 @@ private:
 
     std::condition_variable dataInQueue;
 
+    mutable std::mutex idlingThreadMutex;
+    mutable std::condition_variable idlingThread;
     mutable std::atomic_size_t readyQueueSize;
     mutable std::atomic_flag readyQueueLock;
     std::queue<std::function<void()>> readyQueue;


### PR DESCRIPTION
This change makes cask behave better with regards to giving up threads for the host scheduler. While this retains the spinlocking behavior to put things into and out of the ready queue - it uses a condition variable for idling "smartly" (until work is ready) rather than trying to use time as a heuristic. The result is code that has the same throughput as before in terms of how many tasks executed - but is _much_ nicer to the host system.

Note that with these spinlocks in cases where there is continued work to be done this scheduler will be lock free. We only acquire mutexes and things when there isn't work readily available to munch on.