### PR TITLE
fix: handle time changes via steady_clock

### DIFF
--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -109,9 +109,9 @@ void SingleThreadScheduler::timer() {
     const static std::chrono::milliseconds sleep_time(10);
 
     while(running) {
-        auto before = std::chrono::high_resolution_clock::now();
+        auto before = std::chrono::steady_clock::now();
         std::this_thread::sleep_for(sleep_time);
-        auto after = std::chrono::high_resolution_clock::now();
+        auto after = std::chrono::steady_clock::now();
         
         auto delta = after - before;
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();

--- a/src/cask/scheduler/ThreadPoolScheduler.cpp
+++ b/src/cask/scheduler/ThreadPoolScheduler.cpp
@@ -119,9 +119,9 @@ void ThreadPoolScheduler::timer() {
     const static std::chrono::milliseconds sleep_time(10);
 
     while(running) {
-        auto before = std::chrono::high_resolution_clock::now();
+        auto before = std::chrono::steady_clock::now();
         std::this_thread::sleep_for(sleep_time);
-        auto after = std::chrono::high_resolution_clock::now();
+        auto after = std::chrono::steady_clock::now();
         
         auto delta = after - before;
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();


### PR DESCRIPTION
This resolves an issue where the timer thread could get _really_ confused if a time change (e.g. jumping from 1970 to current time) happens at the wrong time of the timer loop. This could lead to the timer thread basically hanging on a for loop iterating for every millisecond of delta between the before (1970) and after (2021) times.

The culprit was the use of `std::chrono::high_resolution_clock` which I mistakenly believed to be monotonic time. It's actually wall clock time. This is trivally resolved by switching to `std::chrono::steady_clock` instead which is guaranteed monotonic and immune to this time change vulnerability in the logic.