### PR TITLE
fix: canceled delay would swallow the cancel and return the next op anyway.

### DIFF
--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -726,8 +726,12 @@ constexpr Task<T2,E> Task<T,E>::dematerialize() const noexcept {
 template <class T, class E>
 constexpr Task<T,E> Task<T,E>::delay(uint32_t milliseconds) const noexcept {
     return Task<T,E>(
-        fiber::FiberOp::delay(milliseconds)->flatMap([op = this->op](auto) {
-            return op;
+        fiber::FiberOp::delay(milliseconds)->flatMap([op = this->op](auto result) {
+            if(result.isCanceled()) {
+                return fiber::FiberOp::cancel();
+            } else {
+                return op;
+            }
         })
     );
 }

--- a/test/cask/task/TestTaskDelay.cpp
+++ b/test/cask/task/TestTaskDelay.cpp
@@ -15,7 +15,7 @@ TEST(TestTaskDelay, DelaysExecution) {
     int counter = 0;
     auto sched = std::make_shared<BenchScheduler>();
 
-    auto deferred = Task<int>::eval([&counter] { return counter++; })
+    auto fiber = Task<int>::eval([&counter] { return counter++; })
         .delay(10)
         .run(sched);
 
@@ -37,13 +37,16 @@ TEST(TestTaskDelay, CancelsExecution) {
     int counter = 0;
     auto sched = std::make_shared<BenchScheduler>();
 
-    auto deferred = Task<int>::eval([&counter] { return counter++; })
+    auto fiber = Task<int>::eval([&counter] { return counter++; })
         .delay(10)
         .run(sched);
 
     sched->run_ready_tasks();
     EXPECT_EQ(sched->num_timers(), 1);
 
-    deferred->cancel();
+    fiber->cancel();
+    sched->run_ready_tasks();
     EXPECT_EQ(sched->num_timers(), 0);
+    EXPECT_TRUE(fiber->isCanceled());
 }
+


### PR DESCRIPTION
This change resolves a regression in `Task::delay` where they could no longer be canceled properly. After a cancel, the `Task::delay` would simply return the delayed op anyway and `Fiber` would essentially act as if it had recovered from the cancel. This change puts the proper check in so that the cancel properly propogates.