### PR TITLE
fix: allow async boundaries to be canceled.

### DIFF
--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -488,8 +488,12 @@ constexpr Task<T,E> Task<T,E>::asyncBoundary() const noexcept {
             auto promise = Promise<Erased,Erased>::create(sched);
             promise->success(Erased());
             return Deferred<Erased,Erased>::forPromise(promise);
-        })->flatMap([op = op](auto) {
-            return op;
+        })->flatMap([op = op](auto fiber_value) {
+            if(fiber_value.isCanceled()) {
+                return fiber::FiberOp::cancel();
+            } else {
+                return op;
+            }
         })
     );
 }

--- a/test/cask/task/TestTaskAsyncBoundary.cpp
+++ b/test/cask/task/TestTaskAsyncBoundary.cpp
@@ -1,0 +1,36 @@
+//          Copyright Tango Tango, Inc. 2020 - 2021.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include "gtest/gtest.h"
+#include "cask/Task.hpp"
+#include "cask/scheduler/BenchScheduler.hpp"
+
+using cask::Task;
+using cask::scheduler::BenchScheduler;
+
+TEST(TaskAsyncBoundary, DefersExecutionToScheduler) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto fiber = Task<int,std::string>::pure(123).asyncBoundary().run(sched);
+
+    EXPECT_FALSE(fiber->getValue().has_value());
+    EXPECT_FALSE(sched->isIdle());
+
+    sched->run_ready_tasks();
+    EXPECT_TRUE(sched->isIdle());
+    EXPECT_TRUE(fiber->getValue().has_value());
+    EXPECT_EQ(*(fiber->getValue()), 123);
+}
+
+TEST(TaskAsyncBoundary, AllowsCancelation) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto fiber = Task<int,std::string>::pure(123).asyncBoundary().run(sched);
+
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_TRUE(sched->isIdle());
+    EXPECT_TRUE(fiber->isCanceled());
+}
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -42,6 +42,7 @@ if not meson.is_subproject()
         'cask/scheduler/TestSingleThreadScheduler.cpp',
         'cask/scheduler/TestThreadPoolScheduler.cpp',
         'cask/task/TestTaskAssignment.cpp',
+        'cask/task/TestTaskAsyncBoundary.cpp',
         'cask/task/TestTaskDefer.cpp',
         'cask/task/TestTaskDeferFiber.cpp',
         'cask/task/TestTaskDelay.cpp',


### PR DESCRIPTION
This change resolves an issue where async boundaries would ignore cancellations.