### PR TITLE
fix: resolve random sigabrt by detaching scheduler threads.

### DIFF
--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -47,8 +47,10 @@ public:
 private:
     using TimerEntry = std::tuple<int64_t, std::function<void()>>;
 
-    bool running;
-    bool idle;
+    std::atomic_bool should_run;
+    std::atomic_bool idle;
+    std::atomic_bool timer_running;
+    std::atomic_bool runner_running;
 
     std::condition_variable dataInQueue;
 
@@ -59,8 +61,6 @@ private:
     std::queue<std::function<void()>> readyQueue;
     std::mutex timerMutex;
     std::map<int64_t,std::vector<TimerEntry>> timers;
-    std::thread runThread;
-    std::thread timerThread;
     int64_t ticks;
     int64_t next_id;
 

--- a/include/cask/scheduler/ThreadPoolScheduler.hpp
+++ b/include/cask/scheduler/ThreadPoolScheduler.hpp
@@ -42,7 +42,7 @@ public:
 private:
     using TimerEntry = std::tuple<int64_t, std::function<void()>>;
 
-    bool running;
+    std::atomic_bool should_run;
 
     std::mutex readyQueueMutex;
     std::condition_variable dataInQueue;
@@ -50,12 +50,12 @@ private:
     std::atomic_size_t idleThreads;
     std::mutex timerMutex;
     std::map<int64_t,std::vector<TimerEntry>> timers;
-    std::vector<std::thread> runThreads;
-    std::thread timerThread;
+    std::vector<std::atomic_bool*> threadStatus;
+    std::atomic_bool timerThreadStatus;
     int64_t ticks;
     int64_t next_id;
 
-    void run();
+    void run(unsigned int thread_index);
     void timer();
 
     class CancelableTimer final : public Cancelable {


### PR DESCRIPTION
This change avoids some weird behavior surrounding destruction of `std::thread` by detaching the thread pulling shutdown handling into our own hands. I'm also shifting to atomics to avoid any strange-ness with multiple threads reading and setting their flags.

This didn't seem to cause issues often on x86 - but on MIPS (and uclibc) I saw _regular_ test failures due to sigabrt in the test bench of another project. These changes seem to address those issues.
