### PR TITLE
perf: pool FiberOp instances

### DIFF
--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -16,7 +16,6 @@
 #include "../Either.hpp"
 #include "../Erased.hpp"
 #include "../Scheduler.hpp"
-#include "../pool/InternalPool.hpp"
 
 namespace cask {
 
@@ -29,15 +28,6 @@ using DeferredRef = std::shared_ptr<Deferred<T,E>>;
 }
 
 namespace cask::fiber {
-
-template <class T>
-class PoolDeleter {
-public:
-    void operator()(T* ptr) {
-        pool::global_pool().deallocate<T>(ptr);
-    }
-};
-
 
 enum FiberOpType { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RACE, CANCEL };
 

--- a/src/cask/fiber/FiberOp.cpp
+++ b/src/cask/fiber/FiberOp.cpp
@@ -13,6 +13,14 @@ using cask::pool::global_pool;
 
 namespace cask::fiber {
 
+template <class T>
+class PoolDeleter {
+public:
+    void operator()(T* ptr) {
+        global_pool().deallocate<T>(ptr);
+    }
+};
+
 FiberOp::FiberOp(AsyncData* async) noexcept
     : opType(ASYNC)
 {


### PR DESCRIPTION
This change improves performance a bit by allocating `FiberOp` instances on the global pool. These instances are small and they are allocated / deallocated frequently at runtime. Putting them on the pool helps avoid thrashing the system memory manager, leading to a bit of a performance gain (around 10% in a real-world workload).