### PR TITLE
fix: avoid deadlocks caused by a fiber canceling itself.

### DIFF
--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -482,6 +482,11 @@ void FiberImpl<T,E>::cancel() {
             if(state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
                 break;
             }
+        } else if (auto sched = last_used_scheduler.lock()) {
+            sched->submit([self = this->shared_from_this()] {
+                self->cancel();
+            });
+            return;
         }
     }
 


### PR DESCRIPTION
This change addresses an issue where an application could deadlock on the single threaded scheduler if a fiber attempts to cancel _itself_ either directly or _indirectly_. In this situation, previously the cancel operation would hang forever attempting to spinlock into the running state - but this could never happen because the thread doing the spinlocking is _already_ running.

With this change - rather than spin locking the Fiber will attempt to schedule the cancel if needed on the last used scheduler. The behavior change doesn't effect any user facing behavior - cancels have always been "best effort" in terms of when their effect lands. It just may be that in more situations than before the cancel doesn't get processed synchronously with the call to `cancel`. This is a small price to pay for removing a deadlock.