### PR TITLE
fix: avoid double-canceling racing fibers.

### DIFF
--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -555,9 +555,10 @@ void FiberImpl<T,E>::cancel() {
             }
         }
 
-        for(auto& fiber : local_racers) {
-            fiber->cancel();
+        if (!local_racers.empty()) {
+            local_racers[0]->cancel();
         }
+        
         return;
     }
     

--- a/test/cask/task/TestTaskGuarantee.cpp
+++ b/test/cask/task/TestTaskGuarantee.cpp
@@ -84,3 +84,262 @@ TEST(TaskGuarantee, AlwaysRuns) {
     
     EXPECT_EQ(counter, 1);
 }
+
+TEST(TaskGuarantee, StackedGuarantees) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+    auto deferred = Task<int>::never()
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    deferred->cancel();
+    sched->run_ready_tasks();
+
+    try {
+        deferred->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 2);
+}
+
+TEST(TaskGuarantee, StackedAsyncGuarantee) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto promise = cask::Promise<None>::create(sched);
+    auto counter = 0;
+    auto deferred = Task<int>::never()
+        .guarantee(Task<None>::deferAction([&counter, promise](auto) {
+            counter++;
+            return cask::Deferred<None>::forPromise(promise);
+        }))
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    deferred->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    promise->success(None());
+    sched->run_ready_tasks();
+    EXPECT_EQ(counter, 2);
+
+    try {
+        deferred->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 2);
+}
+
+TEST(TaskGuarantee, RacedGuarantees) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+    auto first_task = Task<int>::never()
+        .guarantee(Task<None>::eval([&counter] {
+            std::cout << "First Task Guarantee!" << std::endl;
+            counter++;
+            return None();
+        }));
+
+    auto second_task = Task<int>::never()
+        .guarantee(Task<None>::eval([&counter] {
+            std::cout << "Second Task Guarantee!" << std::endl;
+            counter++;
+            return None();
+        }));
+
+    auto third_task = Task<int>::never()
+        .guarantee(Task<None>::eval([&counter] {
+            std::cout << "Third Task Guarantee!" << std::endl;
+            counter++;
+            return None();
+        }));
+
+    auto fiber = first_task
+        .raceWith(second_task)
+        .raceWith(third_task)
+        .guarantee(Task<None>::eval([&counter] {
+            std::cout << "Fiber Guarantee!" << std::endl;
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    sched->run_ready_tasks();
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 4);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 4);
+}
+
+TEST(TaskGuarantee, GuaranteePureValueRace) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::pure(1)
+        .raceWith(Task<int>::pure(2))
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(TaskGuarantee, GuaranteePureNeverRace) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::pure(1)
+        .raceWith(Task<int>::never())
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(TaskGuarantee, GuaranteeNeverPureRace) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::never()
+        .raceWith(Task<int>::pure(1))
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(TaskGuarantee, GuaranteeNeverNeverRace) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::never()
+        .raceWith(Task<int>::never())
+        .guarantee(Task<None>::eval([&counter] {
+            counter++;
+            return None();
+        }))
+        .run(sched);
+
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(TaskGuarantee, RaceGuaranteedInnerTask) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::never()
+        .raceWith(
+            Task<int>::never().guarantee(Task<None>::eval([&counter] {
+                counter++;
+                return None();
+            })
+        ))
+        .run(sched);
+
+    sched->run_ready_tasks();
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(TaskGuarantee, RaceDoOnCancelInnerTask) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto counter = 0;
+
+    auto fiber = Task<int>::never()
+        .raceWith(
+            Task<int>::never().doOnCancel(Task<None,None>::eval([&counter] {
+                counter++;
+                return None();
+            })
+        ))
+        .run(sched);
+
+    sched->run_ready_tasks();
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    EXPECT_EQ(counter, 1);
+
+    try {
+        fiber->await();
+        FAIL() << "Expected method to throw";
+    } catch(std::runtime_error&) {}
+    
+    EXPECT_EQ(counter, 1);
+}

--- a/test/cask/task/TestTaskGuarantee.cpp
+++ b/test/cask/task/TestTaskGuarantee.cpp
@@ -145,32 +145,16 @@ TEST(TaskGuarantee, StackedAsyncGuarantee) {
 TEST(TaskGuarantee, RacedGuarantees) {
     auto sched = std::make_shared<BenchScheduler>();
     auto counter = 0;
-    auto first_task = Task<int>::never()
+    auto task = Task<int>::never()
         .guarantee(Task<None>::eval([&counter] {
-            std::cout << "First Task Guarantee!" << std::endl;
             counter++;
             return None();
         }));
 
-    auto second_task = Task<int>::never()
+    auto fiber = task
+        .raceWith(task)
+        .raceWith(task)
         .guarantee(Task<None>::eval([&counter] {
-            std::cout << "Second Task Guarantee!" << std::endl;
-            counter++;
-            return None();
-        }));
-
-    auto third_task = Task<int>::never()
-        .guarantee(Task<None>::eval([&counter] {
-            std::cout << "Third Task Guarantee!" << std::endl;
-            counter++;
-            return None();
-        }));
-
-    auto fiber = first_task
-        .raceWith(second_task)
-        .raceWith(third_task)
-        .guarantee(Task<None>::eval([&counter] {
-            std::cout << "Fiber Guarantee!" << std::endl;
             counter++;
             return None();
         }))


### PR DESCRIPTION
This change resolves an issue where guarantees (or other "on cancel" operations) would sometimes not be performed on racing fibers. This ended up being caused by a double-cancel in `FiberImpl` itself where canceling the parent fiber would cancel all racers - and when the first cancel completed it would _again_ cancel all the other fibers.

The solution is just to cancel the other fibers. This will result in all of the other fibers getting canceled as well and avoids the double-cancel situation entirely.