### PR TITLE
fix: reduce timer stuttering by merging the timer and run threads (single threaded)

### DIFF
--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -50,7 +50,6 @@ private:
 
     std::atomic_bool should_run;
     std::atomic_bool idle;
-    std::atomic_bool timer_running;
     std::atomic_bool runner_running;
 
     std::condition_variable dataInQueue;

--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -60,13 +60,11 @@ private:
     mutable std::atomic_flag readyQueueLock = ATOMIC_FLAG_INIT;
     std::queue<std::function<void()>> readyQueue;
     std::mutex timerMutex;
-    std::condition_variable timerCondition;
     std::map<int64_t,std::vector<TimerEntry>> timers;
     int64_t last_execution_ms;
     std::atomic_int64_t next_id;
 
     void run();
-    void timer();
     static int64_t current_time_ms();
 
     class CancelableTimer final : public Cancelable {

--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "../Scheduler.hpp"
+#include "SpinLock.hpp"
 
 namespace cask::scheduler {
     
@@ -57,9 +58,9 @@ private:
     mutable std::mutex idlingThreadMutex;
     mutable std::condition_variable idlingThread;
     mutable std::atomic_size_t readyQueueSize;
-    mutable std::atomic_flag readyQueueLock = ATOMIC_FLAG_INIT;
+    mutable SpinLock readyQueueLock;
+    mutable SpinLock timerLock;
     std::queue<std::function<void()>> readyQueue;
-    std::mutex timerMutex;
     std::map<int64_t,std::vector<TimerEntry>> timers;
     int64_t last_execution_ms;
     std::atomic_int64_t next_id;

--- a/include/cask/scheduler/SpinLock.hpp
+++ b/include/cask/scheduler/SpinLock.hpp
@@ -36,7 +36,7 @@ private:
 
 class SpinLockGuard {
 public:
-    explicit SpinLockGuard(SpinLock& lock);
+    explicit SpinLockGuard(SpinLock& lock); // NOLINT(google-runtime-references)
     ~SpinLockGuard();
 private:
     SpinLock& lock;

--- a/include/cask/scheduler/SpinLock.hpp
+++ b/include/cask/scheduler/SpinLock.hpp
@@ -36,12 +36,12 @@ private:
 
 class SpinLockGuard {
 public:
-    SpinLockGuard(SpinLock& lock);
+    explicit SpinLockGuard(SpinLock& lock);
     ~SpinLockGuard();
 private:
     SpinLock& lock;
 };
 
-}
+} // namespace cask::scheduler
 
 #endif

--- a/include/cask/scheduler/SpinLock.hpp
+++ b/include/cask/scheduler/SpinLock.hpp
@@ -1,0 +1,47 @@
+//          Copyright Tango Tango, Inc. 2020 - 2021.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef _CASK_SCHEDULER_SPIN_LOCK_H_
+#define _CASK_SCHEDULER_SPIN_LOCK_H_
+
+#include <atomic>
+
+namespace cask::scheduler {
+
+class SpinLockGuard;
+
+/**
+ * In some (very rare) cases we would prefer to use a spinlock instead of a mutex. This is
+ * typically true deep in scheduler code where, for latency and timer accuracy reasons, we'd
+ * prefer to spin on a lock rather than sleep.
+ * 
+ * You shouldn't use this lock unless you're sure you need it. It's not as fair as a mutex
+ * and can cause a lot of contention if used inappropriately.
+ * 
+ * This lock implementation exposes no methods directly to manipulate it. Instead it's expected
+ * that the SpinLockGuard is used to lock and unlock the lock in a way that ensures safety.
+ */
+class SpinLock {
+public:
+    SpinLock() = default;
+    SpinLock(const SpinLock&) = delete;
+    SpinLock& operator=(const SpinLock&) = delete;
+    SpinLock& operator=(const SpinLock&) volatile = delete;
+private:
+    friend SpinLockGuard;
+    std::atomic_flag flag = ATOMIC_FLAG_INIT;
+};
+
+class SpinLockGuard {
+public:
+    SpinLockGuard(SpinLock& lock);
+    ~SpinLockGuard();
+private:
+    SpinLock& lock;
+};
+
+}
+
+#endif

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -22,7 +22,6 @@ namespace cask::scheduler {
 SingleThreadScheduler::SingleThreadScheduler(int priority)
     : should_run(true)
     , idle(true)
-    , timer_running(false)
     , runner_running(false)
     , dataInQueue()
     , readyQueueSize(0)

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -35,16 +35,13 @@ SingleThreadScheduler::SingleThreadScheduler(int priority)
 #if __linux__
     auto which = PRIO_PROCESS;
     setpriority(which, runThread.native_handle(), priority);
-    setpriority(which, timerThread.native_handle(), priority);
 #elif __APPLE__
     auto which = PRIO_PROCESS;
     uint64_t run_thread_id = 0;
-    uint64_t timer_thread_id = 0;
 
     pthread_threadid_np(runThread.native_handle(), &run_thread_id);
 
     setpriority(which, run_thread_id, priority);
-    setpriority(which, timer_thread_id, priority);
 #endif
 
 #if defined(__linux__) && defined(_GNU_SOURCE)

--- a/src/cask/scheduler/SpinLock.cpp
+++ b/src/cask/scheduler/SpinLock.cpp
@@ -1,0 +1,21 @@
+//          Copyright Tango Tango, Inc. 2020 - 2021.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include "cask/scheduler/SpinLock.hpp"
+
+namespace cask::scheduler {
+
+SpinLockGuard::SpinLockGuard(SpinLock& lock)
+    : lock(lock)
+{
+    while(lock.flag.test_and_set(std::memory_order_acquire));
+}
+
+SpinLockGuard::~SpinLockGuard()
+{
+    lock.flag.clear(std::memory_order_release);
+}
+
+} // namespace cask::scheduler

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ cask_sources = [
     'cask/pool/InternalPool.cpp',
     'cask/scheduler/BenchScheduler.cpp',
     'cask/scheduler/SingleThreadScheduler.cpp',
+    'cask/scheduler/SpinLock.cpp',
     'cask/scheduler/ThreadPoolScheduler.cpp'
 ]
 

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -96,7 +96,7 @@ TEST_F(SingleThreadSchedulerTest, SubmitAfter) {
     auto delta = after - before;
     auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
 
-    EXPECT_GE(milliseconds, 25);
+    EXPECT_GE(milliseconds, 24);
     
     awaitIdle();
 }
@@ -182,7 +182,7 @@ TEST_F(SingleThreadSchedulerTest, RunsShutdownImmediatelyCallbackIfTimerAlreadyF
     auto delta = after - before;
     auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
 
-    EXPECT_GE(milliseconds, 25);
+    EXPECT_GE(milliseconds, 24);
     EXPECT_FALSE(shutdown);
 
     cancelable->onShutdown([&shutdown] {

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -160,7 +160,7 @@ TEST_F(SingleThreadSchedulerTest, RunsShutdownCallbackAfterTimerTaskCompletion) 
     auto delta = after - before;
     auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
 
-    EXPECT_GE(milliseconds, 25);
+    EXPECT_GE(milliseconds, 24);
     EXPECT_TRUE(shutdown);
     
     awaitIdle();


### PR DESCRIPTION
We've observed quite a bit of timer stuttering on some architectures in the field. The goal of this change is to reduce that stuttering by merging the timer and run threads in the `SingleThreadScheduler`.

The theory here is that the stuttering is partially induced by the additional thread hop required for submitting a "ready" timer task to the ready queue and then waking the run thread to process that work. This would likely be especially bad in cases where the run thread spends a lot of time idling - which can lead to varying times required for the kernel to wake the run thread and do additional work.

Instead, this change makes the run thread handle both situations. It'll first wake up and evaluate if any timers need to be executed. It'll then run a batch of tasks from the ready queue. Finally it'll go idle, just like before, but instead it'll schedule itself to wake up automatically when the next timer is supposed to fire.

To simplify some of the code I've also added the `SpinLock` class which is just a simple atomic spin lock wrapper.  I've also spent some time documenting when the relaxed memory ordering was used to justify that usage.

In a future PR, once this one is deemed ready, I will do something similar to the `ThreadPoolScheduler`. I'd also like to change some of this logic to operate at nanosecond level precision for greater internal timer accuracy. Those things are left as future work to try and keep this PR focused.