### PR TITLE
fix: resolve data races when racing fibers

### DIFF
--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -19,15 +19,15 @@ namespace cask::fiber {
 
 enum FiberState { READY, RUNNING, WAITING, DELAYED, RACING, COMPLETED, CANCELED };
 
-#define PRINT_STATE(state) \
-    (state == READY ? "READY" : \
-    (state == RUNNING ? "RUNNING" : \
-    (state == WAITING ? "WAITING" : \
-    (state == DELAYED ? "DELAYED" : \
-    (state == RACING ? "RACING" : \
-    (state == COMPLETED ? "COMPLETED" : \
-    (state == CANCELED ? "CANCELED" : "UNKNOWN")))))))
-
+constexpr const char * print_state(const FiberState& state) {
+    return state == READY ? "READY" :
+           state == RUNNING ? "RUNNING" :
+           state == WAITING ? "WAITING" :
+           state == DELAYED ? "DELAYED" :
+           state == RACING ? "RACING" :
+           state == COMPLETED ? "COMPLETED" :
+           state == CANCELED ? "CANCELED" : "UNKNOWN";
+}
 
 template <class T, class E>
 class FiberImpl final : public Fiber<T,E> {
@@ -252,7 +252,7 @@ void FiberImpl<T,E>::asyncError(const Erased& error) {
             return;
         } else {
             std::string message = "Fiber is in invalid state to process asyncError: ";
-            throw std::runtime_error(message + PRINT_STATE(current_state));
+            throw std::runtime_error(message + print_state(current_state));
         }
     }
 
@@ -278,7 +278,7 @@ void FiberImpl<T,E>::asyncSuccess(const Erased& new_value) {
             return;
         } else {
             std::string message = "Fiber is in invalid state to process asyncSuccess: ";
-            throw std::runtime_error(message + PRINT_STATE(current_state));
+            throw std::runtime_error(message + print_state(current_state));
         }
     }
 
@@ -304,7 +304,7 @@ void FiberImpl<T,E>::asyncCancel() {
             return;
         } else {
             std::string message = "Fiber is in invalid state to process asyncCancel: ";
-            throw std::runtime_error(message + PRINT_STATE(current_state));
+            throw std::runtime_error(message + print_state(current_state));
         }
     }
 
@@ -330,7 +330,7 @@ void FiberImpl<T,E>::delayFinished() {
             return;
         } else {
             std::string message = "Fiber is in invalid state to process delayFinished: ";
-            throw std::runtime_error(message + PRINT_STATE(current_state));
+            throw std::runtime_error(message + print_state(current_state));
         }
     }
 
@@ -355,7 +355,7 @@ void FiberImpl<T,E>::delayCanceled() {
             return;
         } else {
             std::string message = "Fiber is in invalid state to process delayCanceled: ";
-            throw std::runtime_error(message + PRINT_STATE(current_state));
+            throw std::runtime_error(message + print_state(current_state));
         }
     }
 

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -245,7 +245,7 @@ void FiberImpl<T,E>::asyncError(const Erased& error) {
 
         if (current_state == WAITING && state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
             break;
-        } else if (current_state == RUNNING) {
+        } else if (current_state == RUNNING || current_state == WAITING) {
             continue;
         } else if (current_state == CANCELED || current_state == COMPLETED) {
             waitingOn = nullptr;
@@ -271,7 +271,7 @@ void FiberImpl<T,E>::asyncSuccess(const Erased& new_value) {
 
         if (current_state == WAITING && state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
             break;
-        } else if (current_state == RUNNING) {
+        } else if (current_state == RUNNING || current_state == WAITING) {
             continue;
         } else if (current_state == CANCELED || current_state == COMPLETED) {
             waitingOn = nullptr;
@@ -297,7 +297,7 @@ void FiberImpl<T,E>::asyncCancel() {
 
         if (current_state == WAITING && state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
             break;
-        } else if (current_state == RUNNING) {
+        } else if (current_state == RUNNING || current_state == WAITING) {
             continue;
         } else if (current_state == CANCELED || current_state == COMPLETED) {
             waitingOn = nullptr;
@@ -323,7 +323,7 @@ void FiberImpl<T,E>::delayFinished() {
 
         if (current_state == DELAYED && state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
             break;
-        } else if (current_state == RUNNING) {
+        } else if (current_state == RUNNING || current_state == DELAYED) {
             continue;
         } else if (current_state == CANCELED || current_state == COMPLETED) {
             delayedBy = nullptr;
@@ -348,7 +348,7 @@ void FiberImpl<T,E>::delayCanceled() {
 
         if (current_state == DELAYED && state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
             break;
-        } else if (current_state == RUNNING) {
+        } else if (current_state == RUNNING || current_state == DELAYED) {
             continue;
         } else if (current_state == CANCELED || current_state == COMPLETED) {
             delayedBy = nullptr;

--- a/soak_test.sh
+++ b/soak_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+BUILD_FOLDER=$1
+shift
+
+I=1
+
+meson compile -C "${BUILD_FOLDER}"
+
+while true; do
+	echo
+	echo
+	echo "=====> Test Run #${I}"
+	if ! ${BUILD_FOLDER}/test/testexe $@; then
+		echo
+		echo
+		echo "!!!! Tests Failed on Run #${I}"
+		exit 1
+	fi
+
+	((I=I+1))
+done
+

--- a/test/cask/task/TestTaskRace.cpp
+++ b/test/cask/task/TestTaskRace.cpp
@@ -6,10 +6,12 @@
 #include "gtest/gtest.h"
 #include "cask/Task.hpp"
 #include "cask/scheduler/BenchScheduler.hpp"
+#include "cask/scheduler/WorkStealingScheduler.hpp"
 
 using cask::None;
 using cask::Task;
 using cask::scheduler::BenchScheduler;
+using cask::scheduler::WorkStealingScheduler;
 
 TEST(TaskRace, LeftValue) {
     auto sched = std::make_shared<BenchScheduler>();
@@ -64,4 +66,22 @@ TEST(TaskRace, Cancelled) {
         deferred->await();
         FAIL() << "Expected method to throw.";
     } catch(std::runtime_error&) {}
+}
+
+TEST(TaskRace, TaskStressTest) {
+    auto iterations = 10000;
+    auto sched = std::make_shared<WorkStealingScheduler>();
+
+    while (iterations > 0) {
+        auto task1 = Task<std::size_t,std::string>::pure(SIZE_T_MAX).delay(0);
+        auto task2 = Task<std::size_t,std::string>::raiseError("Error").asyncBoundary();
+        auto race = task1.raceWith(task2).materialize();
+        auto result = race.run(sched)->await();
+
+        if (result.is_left()) {
+            EXPECT_EQ(result.get_left(), SIZE_T_MAX);
+        } else {
+            EXPECT_EQ(result.get_right(), "Error");
+        }
+    }
 }

--- a/test/cask/task/TestTaskRace.cpp
+++ b/test/cask/task/TestTaskRace.cpp
@@ -73,13 +73,14 @@ TEST(TaskRace, TaskStressTest) {
     auto sched = std::make_shared<WorkStealingScheduler>();
 
     while (iterations > 0) {
-        auto task1 = Task<std::size_t,std::string>::pure(SIZE_T_MAX).delay(0);
+        iterations--;
+        auto task1 = Task<std::size_t,std::string>::pure(SIZE_MAX).delay(0);
         auto task2 = Task<std::size_t,std::string>::raiseError("Error").asyncBoundary();
         auto race = task1.raceWith(task2).materialize();
         auto result = race.run(sched)->await();
 
         if (result.is_left()) {
-            EXPECT_EQ(result.get_left(), SIZE_T_MAX);
+            EXPECT_EQ(result.get_left(), SIZE_MAX);
         } else {
             EXPECT_EQ(result.get_right(), "Error");
         }


### PR DESCRIPTION
This change resolves several independent issues which could all lead to various data races when racing fibers that were either (a) delayed or (b) waiting on some async boundary. Both of these cases were pretty common and could lead to various crashes I've seen running this code in the field.

To reveal these issues a single test was added that specifically exercises this code path as a stress test. This test case revealed several issues which all contributed to potentially buggy behavior with anything that performed a `race` (like `timeout`) or tried to call `cancel` from code executing concurrently to the thread a fiber was executing on.

To get that stress test to run cleanly, the following issues were resolved:

1. There was a small chance than and async or delay callback could race with a concurrent cancel. In these situations the callback would observe a fiber in the `RUNNING` state (because the cancel was being processed) rather than the expected `WAITING` or `DELAYED` state. The resolution is to busy wait inside the callback for the fiber to stop `RUNNING` indicating that the cancel call has finished its processing - and then continue processing the callback.
2. There was a chance that a delay could be de-allocated _while_ it was processing a cancel callback - leading to weird mutex errors due to corrupted data. The resolution here is applied in several different ways:

    -  The timer logic has been refactored so that `SingleThreadScheduler` holds onto instances of `CancelableTimer` until it is done with them (either by firing the timer or seeing it canceled). This means that an external observer simply dropping the handle won't invalidate these.
    - `FiberImpl` copies the `delayedBy` and `waitingOn` references to local copies before releasing atomic state and calling `cancel` to avoid a race where a parallel thread completes a callback and nulls those pointers.
    - Callbacks are `std::swap`ed into a stack-local store before executing them, to further prevent issues with these callbacks turning around and messing with shared state leading to crashes.

3. When racing fibers, there was previously a chance that multiple racing calls to `racerFinished` could _both_ observe that the queue was empty resulting in multiple "completions" of the monitor fiber in concurrent contexts - leading to data corruption. The logic of `racerFinished` has been refactored to avoid this issue by making all important decisions inside of a single lock hold rather than releasing a lock, messing with atomics, and then locking again - which was far harder to reason about.

Finally, to avoid these issues with callbacks not firing correctly in the future logic was added to throw a `std::runtime_error` if some state is encountered in those callbacks that isn't valid - which should lead to finding these issues quicker in the future.