### PR TITLE
fix: avoid queue put and takes lists filled with canceled tasks

### DIFF
--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        target: [debug, release, release_no_atomics, release_always_async, release_forced_cede_disabled, clang, mips, arm]
+        target: [debug, release, release_no_atomics, release_forced_cede_disabled, clang, mips, arm]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/include/cask/List.hpp
+++ b/include/cask/List.hpp
@@ -96,6 +96,17 @@ public:
     virtual ListRef<T> dropWhile(const std::function<bool(const T&)>& predicate) const = 0;
 
     /**
+     * Remove all elements from the list which do not match the given
+     * predicate.
+     * 
+     * @param predicate The function to evaluate and retain items
+     *                  for which it returns true.
+     * @return A list with elements matching the predicate
+     *         dropped.
+     */ 
+    virtual ListRef<T> filter(const std::function<bool(const T&)>& predicate) const = 0;
+
+    /**
      * Execute the given predicate function for each element in the list.
      * 
      * @param predicate The function to evaluate for each element of the list.

--- a/include/cask/list/ListEntry.hpp
+++ b/include/cask/list/ListEntry.hpp
@@ -26,6 +26,7 @@ public:
     std::optional<T> head() const override;
     ListRef<T> tail() const override;
     ListRef<T> dropWhile(const std::function<bool(const T&)>& predicate) const override;
+    ListRef<T> filter(const std::function<bool(const T&)>& predicate) const override;
     void foreach(const std::function<void(const T&)>& predicate) const override;
 
 private:
@@ -112,6 +113,27 @@ ListRef<T> ListEntry<T>::dropWhile(const std::function<bool(const T&)>& predicat
     }
 
     return entry;
+}
+
+template <class T>
+ListRef<T> ListEntry<T>::filter(const std::function<bool(const T&)>& predicate) const {
+    ListRef<T> filtered = List<T>::empty();
+    ListRef<T> entry = this->shared_from_this();
+
+    while(true) {
+        auto valueOpt = entry->head();
+        if(valueOpt.has_value()) {
+            if(predicate(*valueOpt)) {
+                filtered = filtered->append(*valueOpt);
+            }
+
+            entry = entry->tail();
+        } else {
+            break;
+        }
+    }
+
+    return filtered;
 }
 
 template <class T>

--- a/include/cask/list/Nil.hpp
+++ b/include/cask/list/Nil.hpp
@@ -25,6 +25,7 @@ public:
     std::optional<T> head() const override;
     ListRef<T> tail() const override;
     ListRef<T> dropWhile(const std::function<bool(const T&)>& predicate) const override;
+    ListRef<T> filter(const std::function<bool(const T&)>& predicate) const override;
     void foreach(const std::function<void(const T&)>& predicate) const override;
 };
 
@@ -71,6 +72,11 @@ ListRef<T> Nil<T>::tail() const {
 
 template <class T>
 ListRef<T> Nil<T>::dropWhile(const std::function<bool(const T&)>&) const {
+    return this->shared_from_this();
+}
+
+template <class T>
+ListRef<T> Nil<T>::filter(const std::function<bool(const T&)>&) const {
     return this->shared_from_this();
 }
 

--- a/test/cask/TestList.cpp
+++ b/test/cask/TestList.cpp
@@ -98,6 +98,23 @@ TEST(List, DropWhileMatchesEverything) {
     EXPECT_EQ(list->size(), 0);
 }
 
+TEST(List, Filter) {
+    auto list = List<int>::empty()
+        ->append(1)
+        ->append(2)
+        ->append(3)
+        ->append(4)
+        ->append(5)
+        ->filter([](auto value) { return value % 2 == 1; });
+    
+    EXPECT_FALSE(list->is_empty());
+    EXPECT_EQ(list->size(), 3);
+    EXPECT_EQ(*(list->head()), 1);
+    EXPECT_EQ(*(list->tail()->head()), 3);
+    EXPECT_EQ(*(list->tail()->tail()->head()), 5);
+    EXPECT_TRUE(list->tail()->tail()->tail()->is_empty());
+}
+
 TEST(List, Foreach) {
     int sum = 0;
 


### PR DESCRIPTION
We've seen a crash where sometimes queue takes and puts can get into a bad access pattern where the those lists end up filling with _canceled_ promises that don't get reaped because they are _deep_ in the list _after_ some valid entry and `dropWhile` doesn't catch them.

The end result is that _freeing_ a `QueueState` can end up causing a free of a large `List` which happens recursively on the stack for each `ListEntry` in that list. This leads to a stack overflow.

This change adjusts that logic to use a new `filter` method. This is somewhat less efficient, but not in a way that should matter in normal workloads with small numbers of blocked puts and takes. The benefit is far better correctness, and it totally avoids this bad access pattern.

The new `Queue.StressTest` method covers this by artificially creating the bad access pattern. On some platforms, doing repeated takes that are raced with 0 timeout creates the situation _quickly_. The stack traces captured when this fails matches stack traces seen from core dumps in the field.