### PR TITLE
fix: avoid holding strong references to and `self` in async steps

### DIFF
--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install Brew Development Dependencies
       run: brew install ninja
     - name: Install Python Development Dependencies
-      run: sudo python3 -m pip install meson==1.0.0
+      run: sudo pipx install meson==1.0.0
     - name: Generate the Build Environment
       run: ./regenerate_env.sh ${{ matrix.target }}
     - name: Compile

--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -65,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         target: [clang]
       fail-fast: false
 

--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install Brew Development Dependencies
       run: brew install ninja
     - name: Install Python Development Dependencies
-      run: sudo pipx install meson==1.0.0
+      run: pipx install meson==1.0.0
     - name: Generate the Build Environment
       run: ./regenerate_env.sh ${{ matrix.target }}
     - name: Compile


### PR DESCRIPTION
This change avoids some reference cycle / memory leak issues I'm seeing occasionally that are induced by some async step in an `Observer` implementation holding onto a strong `self` reference. These self references end up being passed to closures that are held as tasks on the scheduler. This can cause weirdness, especially during shutdown, especially since many observers _also_ hold onto the scheduler itself which creates a potential reference cycle between those closures held on the scheduler and the scheduler itself - among other cases.

To totally avoid the issue, we should just pass weak references down into async steps and then `lock` them as-needed. This sidesteps the issue entirely. In all cases if some closure does run and we can't `lock` the reference, then things should shutdown on their own by returning `Stop` or other similar signal back upstream.