### PR TITLE
chore: upgrade to clang-tidy-18, rm 20.04 from CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*,bugprone-*,performance-*,portability-*'
-WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,google-*,bugprone-*,performance-*,portability-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*,bugprone-*,performance-*,portability-*,-bugprone-reserved-identifier,-bugprone-suspicious-include'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,google-*,bugprone-*,performance-*,portability-*,-bugprone-reserved-identifier,-bugprone-suspicious-include'
 HeaderFilterRegex: '.*/cask/.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     google

--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         target: [debug, release, release_no_atomics, release_forced_cede_disabled, clang, mips, arm]
       fail-fast: false
 
@@ -131,7 +131,7 @@ jobs:
   
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.actor != 'engineering-at-tangotango'
 
     steps:
@@ -142,9 +142,9 @@ jobs:
     - name: Update Apt Cache
       run: sudo apt-get update
     - name: Install Apt Development Dependencies
-      run: sudo apt-get install -y ninja-build python3-pip gcovr cppcheck clang clang-tidy
+      run: sudo apt-get install -y ninja-build pipx gcovr cppcheck clang clang-tidy
     - name: Install Python Development Dependencies
-      run: sudo python3 -m pip install meson==1.0.0
+      run: sudo pipx install meson==1.0.0
     - name: Generate the Build Environment
       run: ./regenerate_env.sh clang
     - name: Run clang-tidy
@@ -152,7 +152,7 @@ jobs:
   
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [build-linux, build-mac, build-windows, analyze]
     if: contains(github.ref, 'main') && github.actor != 'engineering-at-tangotango'
 

--- a/include/cask/Either.hpp
+++ b/include/cask/Either.hpp
@@ -141,12 +141,12 @@ constexpr bool Either<L,R>::is_right() const {
 
 template <class L, class R>
 constexpr L Either<L,R>::get_left() const {
-    return *leftValue;
+    return *leftValue; // NOLINT(bugprone-unchecked-optional-access)
 }
 
 template <class L, class R>
 constexpr R Either<L,R>::get_right() const {
-    return *rightValue;
+    return *rightValue; // NOLINT(bugprone-unchecked-optional-access)
 }
 
 } // namespace cask

--- a/include/cask/Observer.hpp
+++ b/include/cask/Observer.hpp
@@ -16,7 +16,7 @@ namespace cask {
  * should continue by forwarding the next event or (b) processing
  * should stop altogether and the stream should shutdown.
  */
-enum Ack { Continue, Stop };
+enum Ack : std::uint8_t { Continue, Stop };
 
 template <class T, class E>
 class Observer;

--- a/include/cask/Pool.hpp
+++ b/include/cask/Pool.hpp
@@ -22,29 +22,29 @@ private:
     static constexpr std::size_t smallest_block_size = cache_line_size * smallest_block_num_entries;
 
     pool::BlockPool<cache_line_size, smallest_block_size, alignof(std::max_align_t)> small_pool;
-    pool::BlockPool<cache_line_size*2, smallest_block_size / 2, alignof(std::max_align_t)> medium_pool;
-    pool::BlockPool<cache_line_size*4, smallest_block_size / 4, alignof(std::max_align_t)> large_pool;
-    pool::BlockPool<cache_line_size*8, smallest_block_size / 8, alignof(std::max_align_t)> xlarge_pool;
-    pool::BlockPool<cache_line_size*16, smallest_block_size / 16, alignof(std::max_align_t)> xxlarge_pool;
-    pool::BlockPool<cache_line_size*32, smallest_block_size / 32, alignof(std::max_align_t)> xxxlarge_pool;
-    pool::BlockPool<cache_line_size*64, smallest_block_size / 64, alignof(std::max_align_t)> xxxxlarge_pool;
+    pool::BlockPool<cache_line_size*2UL, smallest_block_size / 2, alignof(std::max_align_t)> medium_pool;
+    pool::BlockPool<cache_line_size*4UL, smallest_block_size / 4, alignof(std::max_align_t)> large_pool;
+    pool::BlockPool<cache_line_size*8UL, smallest_block_size / 8, alignof(std::max_align_t)> xlarge_pool;
+    pool::BlockPool<cache_line_size*16UL, smallest_block_size / 16, alignof(std::max_align_t)> xxlarge_pool;
+    pool::BlockPool<cache_line_size*32UL, smallest_block_size / 32, alignof(std::max_align_t)> xxxlarge_pool;
+    pool::BlockPool<cache_line_size*64UL, smallest_block_size / 64, alignof(std::max_align_t)> xxxxlarge_pool;
 };
 
 template <class T, class... Args>
 T* Pool::allocate(Args&&... args) {
     if constexpr (sizeof(T) <= cache_line_size) {
         return small_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 2) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 2UL) {
         return medium_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 4) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 4UL) {
         return large_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 8) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 8UL) {
         return xlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 16) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 16UL) {
         return xxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 32) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 32UL) {
         return xxxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= cache_line_size * 64)  {
+    } else if constexpr (sizeof(T) <= cache_line_size * 64UL)  {
         return xxxxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
     } else {
         return new T(std::forward<Args>(args)...);
@@ -55,17 +55,17 @@ template <class T>
 void Pool::deallocate(T* ptr) {
     if constexpr (sizeof(T) <= cache_line_size) {
         return small_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 2) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 2UL) {
         return medium_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 4) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 4UL) {
         return large_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 8) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 8UL) {
         return xlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 16) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 16UL) {
         return xxlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 32) {
+    } else if constexpr (sizeof(T) <= cache_line_size * 32UL) {
         return xxxlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= cache_line_size * 64)  {
+    } else if constexpr (sizeof(T) <= cache_line_size * 64UL)  {
         return xxxxlarge_pool.template deallocate<T>(ptr);
     } else {
         delete ptr;

--- a/include/cask/deferred/PromiseDeferred.hpp
+++ b/include/cask/deferred/PromiseDeferred.hpp
@@ -107,10 +107,14 @@ T PromiseDeferred<T,E>::await() {
 
     if(canceled) {
         throw std::runtime_error("Awaiting a promise which was canceled");
-    } else if(result->is_left()) {
-        return result->get_left();
+    } else if (result.has_value()) {
+        if(result->is_left()) {
+            return result->get_left();
+        } else {
+            throw result->get_right();
+        }
     } else {
-        throw result->get_right();
+        throw std::runtime_error("Promise completed with no result");
     }
 }
 

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -10,6 +10,7 @@
 #include <climits>
 #include <mutex>
 #include <map>
+#include <cstdint>
 #include "cask/Config.hpp"
 #include "cask/Deferred.hpp"
 #include "cask/Fiber.hpp"
@@ -17,7 +18,7 @@
 
 namespace cask::fiber {
 
-enum FiberState { READY, RUNNING, WAITING, DELAYED, RACING, COMPLETED, CANCELED };
+enum FiberState : std::uint8_t { READY, RUNNING, WAITING, DELAYED, RACING, COMPLETED, CANCELED };
 
 constexpr const char * print_state(const FiberState& state) {
     return state == READY ? "READY" :
@@ -91,7 +92,7 @@ private:
     std::vector<std::function<void(Fiber<T,E>*)>> callbacks;
     std::atomic_bool attempting_cancel;
     std::optional<FiberValue> race_result;
-    std::map<int, std::shared_ptr<Fiber<Erased,Erased>>> racing_fibers;
+    std::map<std::uint64_t, std::shared_ptr<Fiber<Erased,Erased>>> racing_fibers;
 };
 
 template <class T, class E>

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -209,6 +209,9 @@ public:
     #ifdef __GNUC__
         __builtin_unreachable();
     #endif
+    #ifdef _MSC_VER
+        __assume(0);
+    #endif
 }
 
     union {

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -44,7 +44,7 @@ private:
     std::shared_ptr<Pool> pool;
 };
 
-enum FiberOpType { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RACE, CANCEL, CEDE };
+enum FiberOpType : std::uint8_t { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RACE, CANCEL, CEDE };
 
 /**
  * A `FiberOp` represents a trampolined and possibly asynchronous program

--- a/include/cask/mvar/MVarState.hpp
+++ b/include/cask/mvar/MVarState.hpp
@@ -77,8 +77,8 @@ std::tuple<MVarState<T,E>,bool,std::function<void()>> MVarState<T,E>::tryPut(con
         return promise->isCancelled();
     });
 
-    if(!filteredTakes->is_empty()) {
-        auto takePromise = *(filteredTakes->head());
+    if(auto head = filteredTakes->head()) {
+        auto takePromise = *head;
         return std::make_tuple(
             MVarState(sched, valueOpt, pendingPuts, filteredTakes->tail()),
             true,
@@ -134,8 +134,8 @@ std::tuple<MVarState<T,E>,Task<T,E>> MVarState<T,E>::take() const {
             MVarState(sched, {}, filteredPuts, pendingTakes),
             Task<T,E>::pure(*valueOpt)
         );
-    } else if(!filteredPuts->is_empty()) {
-        auto pending = *(filteredPuts->head());
+    } else if(auto head = filteredPuts->head()) {
+        auto pending = *head;
         auto putPromise = std::get<0>(pending);
         auto value = std::get<1>(pending);
         return std::make_tuple(

--- a/include/cask/observable/MergeObserver.hpp
+++ b/include/cask/observable/MergeObserver.hpp
@@ -250,11 +250,19 @@ Task<None,None> MergeObserver<T,E>::errorDownstream() {
     if (stopped.exchange(true)) {
         return Task<None,None>::none();
     } else {
-        return downstream->onError(std::forward<E>(*cached_error))
-            .template map<None>([p = completed_promise](auto){
-                p->success(None());
-                return None();
-            });
+        if (cached_error.has_value()) {
+            return downstream->onError(std::forward<E>(*cached_error))
+                .template map<None>([p = completed_promise](auto){
+                    p->success(None());
+                    return None();
+                });
+        } else {
+            return downstream->onComplete()
+                .template map<None>([p = completed_promise](auto){
+                    p->success(None());
+                    return None();
+                });
+        }
     }
 }
 

--- a/include/cask/observable/QueueOverflowStrategy.hpp
+++ b/include/cask/observable/QueueOverflowStrategy.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace cask::observable {
 
-enum QueueOverflowStrategy {
+enum QueueOverflowStrategy : std::uint8_t {
     TailDrop,
     Backpressure
 };

--- a/include/cask/queue/QueueState.hpp
+++ b/include/cask/queue/QueueState.hpp
@@ -39,8 +39,8 @@ public:
             return !promise->isCancelled();
         });
 
-        if(!filteredTakes->is_empty()) {
-            auto takePromise = *(filteredTakes->head());
+        if(auto head = filteredTakes->head()) {
+            auto takePromise = *head;
             return std::make_tuple(
                 QueueState(sched, max_size, values, filteredPuts, filteredTakes->tail()),
                 true,
@@ -99,8 +99,8 @@ public:
                 values->head(),
                 []{}
             );
-        } else if(!filteredPuts->is_empty()) {
-            auto pending = *(filteredPuts->head());
+        } else if(auto head = filteredPuts->head()) {
+            auto pending = *head;
             auto putPromise = std::get<0>(pending);
             auto value = std::get<1>(pending);
             return std::make_tuple(

--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -27,6 +27,8 @@ constexpr std::size_t DEFAULT_BATCH_SIZE = 128;
  */
 class SingleThreadScheduler final : public Scheduler, public std::enable_shared_from_this<SingleThreadScheduler> {
 public:
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
     /**
      * Construct a single threaded scheduler.
      */
@@ -38,6 +40,8 @@ public:
         const std::function<void()>& on_resume = [](){},
         const std::function<std::vector<std::function<void()>>(std::size_t)>& on_request_work = [](auto){ return std::vector<std::function<void()>>(); }
     );
+
+    // NOLINTEND(bugprone-easily-swappable-parameters)
 
     /**
      * Destruct the scheduler. Destruction waits for all running and timer
@@ -67,10 +71,13 @@ private:
     class CancelableTimer;
 
     struct SchedulerControlData {
+
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         SchedulerControlData(
             const std::function<void()>& on_idle,
             const std::function<void()>& on_resume,
             const std::function<std::vector<std::function<void()>>(std::size_t)>& on_request_work);
+        // NOLINTEND(bugprone-easily-swappable-parameters)
 
         std::atomic_bool thread_running;
 
@@ -89,11 +96,16 @@ private:
 
     class CancelableTimer final : public Cancelable, std::enable_shared_from_this<CancelableTimer> {
     public:
+
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
         CancelableTimer(
             const std::shared_ptr<SchedulerControlData>& control_data,
             TimerTimeMs time_slot,
             TimerId id
         );
+
+        // NOLINTEND(bugprone-easily-swappable-parameters)
 
         void fire();
         void cancel() override;

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -19,6 +19,9 @@ using namespace std::chrono_literals;
 
 namespace cask::scheduler {
 
+
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
 SingleThreadScheduler::SingleThreadScheduler(
     std::optional<int> priority,
     std::optional<int> pinned_core,
@@ -68,6 +71,9 @@ SingleThreadScheduler::SingleThreadScheduler(
     run_thread.detach();
     while(!control_data->thread_running.load(std::memory_order_acquire));
 }
+
+
+// NOLINTEND(bugprone-easily-swappable-parameters)
 
 SingleThreadScheduler::~SingleThreadScheduler() {
     // Incidate that the run thread should shut down
@@ -201,7 +207,7 @@ void SingleThreadScheduler::run(const std::size_t batch_size, const std::shared_
             }
 
             // Fill the batch with ready tasks by draining the ready queue
-            auto batchSize = std::min(control_data->ready_queue.size(), std::size_t(batch_size));
+            auto batchSize = std::min(control_data->ready_queue.size(), batch_size);
 
             // Adjust the batch size based on the number of expired timers
             if (batchSize > expiredTimers.size()) {
@@ -297,6 +303,9 @@ int64_t SingleThreadScheduler::current_time_ms() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
+
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
 SingleThreadScheduler::SchedulerControlData::SchedulerControlData(
     const std::function<void()>& on_idle,
     const std::function<void()>& on_resume,
@@ -313,6 +322,7 @@ SingleThreadScheduler::SchedulerControlData::SchedulerControlData(
     , on_request_work(on_request_work)
 {}
 
+
 SingleThreadScheduler::CancelableTimer::CancelableTimer(
     const std::shared_ptr<SchedulerControlData>& control_data,
     int64_t time_slot,
@@ -327,6 +337,7 @@ SingleThreadScheduler::CancelableTimer::CancelableTimer(
     , shutdown(false)
 {}
 
+// NOLINTEND(bugprone-easily-swappable-parameters)
 
 void SingleThreadScheduler::CancelableTimer::fire() {
     std::vector<std::function<void()>> callbacks_to_run;

--- a/src/cask/scheduler/WorkStealingScheduler.cpp
+++ b/src/cask/scheduler/WorkStealingScheduler.cpp
@@ -94,7 +94,8 @@ std::vector<std::function<void()>> WorkStealingScheduler::onThreadRequestWork(co
     if (auto self = self_weak.lock()) {
         // Select a random starting point for work stealing as a simple way to balance work
         // and avoid lock contention
-        auto random_start_index = std::size_t(std::abs(std::rand())) % self->thread_ids.size();
+        auto dice_roll = static_cast<std::size_t>(std::abs(std::rand()));
+        auto random_start_index = dice_roll % self->thread_ids.size();
         auto i = random_start_index;
 
         while (true) {

--- a/test/cask/TestErased.cpp
+++ b/test/cask/TestErased.cpp
@@ -78,5 +78,5 @@ TEST(Erased, ThrowsEmptyGet) {
         Erased foo;
         foo.get<int>();
         FAIL() << "expected method to throw";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 }

--- a/test/cask/TestFiber.cpp
+++ b/test/cask/TestFiber.cpp
@@ -18,6 +18,8 @@ using cask::fiber::FiberOp;
 using cask::scheduler::BenchScheduler;
 using cask::scheduler::SingleThreadScheduler;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TestFiber, ConstructsSync) {
     auto sched = std::make_shared<BenchScheduler>();
     auto op = FiberOp::value(123);
@@ -440,4 +442,6 @@ TEST(TestFiber, RecoversCancel) {
     ASSERT_TRUE(fiber->getValue().has_value());
     EXPECT_EQ(fiber->getValue(), 456);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)
 

--- a/test/cask/TestList.cpp
+++ b/test/cask/TestList.cpp
@@ -8,6 +8,8 @@
 
 using cask::List;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(List, Empty) {
     auto list = List<int>::empty();
 
@@ -135,3 +137,5 @@ TEST(List, ForeachEmpty) {
     
     EXPECT_EQ(sum, 0);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/TestObservable.cpp
+++ b/test/cask/TestObservable.cpp
@@ -49,7 +49,7 @@ TEST_P(ObservableTest, Eval) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableTest, EvalThrows) {
@@ -73,7 +73,7 @@ TEST_P(ObservableTest, Defer) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableTest, DeferThrows) {
@@ -110,7 +110,7 @@ TEST_P(ObservableTest, DeferTask) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableTest, DeferTaskThrows) {

--- a/test/cask/TestPromiseDeferred.cpp
+++ b/test/cask/TestPromiseDeferred.cpp
@@ -22,6 +22,8 @@ using cask::scheduler::BenchScheduler;
 
 INSTANTIATE_SCHEDULER_TEST_BENCH_SUITE(DeferredTest);
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(DeferredTest, Pure) {
     auto deferred = Deferred<int,float>::pure(123);
     
@@ -270,7 +272,7 @@ TEST_P(DeferredTest, PromiseAwaitAsync) {
     // if the thread stops before we try to join it.
     try {
         backgroundAwait.join();
-    } catch(std::system_error& error) {}
+    } catch(std::system_error& error) {} // NOLINT(bugprone-empty-catch)
 
     // Finally assert that the value as set properly.
     EXPECT_EQ(deferred->await(), 123);
@@ -285,7 +287,7 @@ TEST_P(DeferredTest, PromiseCancel) {
     try {
         deferred->await();
         FAIL() << "Expected operation to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(DeferredTest, PromiseSuccessIgnoresCancel) {
@@ -323,7 +325,7 @@ TEST_P(DeferredTest, PromiseCancelIgnoresSuccess) {
     try {
         deferred->await();
         FAIL() << "Expected operation to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(DeferredTest, PromiseCancelIgnoresError) {
@@ -336,7 +338,7 @@ TEST_P(DeferredTest, PromiseCancelIgnoresError) {
     try {
         deferred->await();
         FAIL() << "Expected operation to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(DeferredTest, PromiseCancelIgnoresSubsequentCancel) {
@@ -349,7 +351,7 @@ TEST_P(DeferredTest, PromiseCancelIgnoresSubsequentCancel) {
     try {
         deferred->await();
         FAIL() << "Expected operation to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(DeferredTest, PromiseCancelAffectsPeers) {
@@ -362,7 +364,7 @@ TEST_P(DeferredTest, PromiseCancelAffectsPeers) {
     try {
         sibling->await();
         FAIL() << "Expected operation to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(DeferredTest, DoesntAllowMultipleSuccesses) {
@@ -590,3 +592,5 @@ TEST(DeferredTest, FiberAwait) {
     EXPECT_EQ(*(fiber->getValue()), 123);
     EXPECT_EQ(deferred->await(), 123);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/TestQueue.cpp
+++ b/test/cask/TestQueue.cpp
@@ -250,7 +250,7 @@ TEST(Queue, TryTakeHasValue) {
 
     auto value_opt = queue->tryTake();
     ASSERT_TRUE(value_opt.has_value());
-    EXPECT_EQ(*value_opt, 1);
+    EXPECT_EQ(*value_opt, 1); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(Queue, TryTakePendingPuts) {
@@ -265,13 +265,13 @@ TEST(Queue, TryTakePendingPuts) {
     {
         auto value_opt = queue->tryTake();
         ASSERT_TRUE(value_opt.has_value());
-        EXPECT_EQ(*value_opt, 1);
+        EXPECT_EQ(*value_opt, 1); // NOLINT(bugprone-unchecked-optional-access)
     }
 
     {
         auto value_opt = queue->tryTake();
         ASSERT_TRUE(value_opt.has_value());
-        EXPECT_EQ(*value_opt, 2);
+        EXPECT_EQ(*value_opt, 2); // NOLINT(bugprone-unchecked-optional-access)
     }
 
     sched->run_ready_tasks();

--- a/test/cask/TestTask.cpp
+++ b/test/cask/TestTask.cpp
@@ -45,7 +45,7 @@ TEST_P(TaskTest, RaiseErrorAsync) {
 TEST_P(TaskTest, RaiseErrorWithoutErrorType) {
     auto task = Task<None, std::optional<int>>::raiseError(123);
     auto result = task.failed().run(sched);
-    EXPECT_EQ(*(result->await()), 123);
+    EXPECT_EQ(*(result->await()), 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(TaskTest, EvalAsync) {

--- a/test/cask/fiber/TestFiberValue.cpp
+++ b/test/cask/fiber/TestFiberValue.cpp
@@ -9,6 +9,8 @@
 using cask::Erased;
 using cask::fiber::FiberValue;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(FiberValue, Empty) {
     FiberValue value;
 
@@ -79,3 +81,5 @@ TEST(FiberValue, ErasedMoveCancel) {
     EXPECT_FALSE(value.isError());
     EXPECT_TRUE(value.isCanceled());
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/observable/TestObservableBuffer.cpp
+++ b/test/cask/observable/TestObservableBuffer.cpp
@@ -21,7 +21,7 @@ TEST(ObservableBuffer,SingleValue) {
 
     ASSERT_TRUE(result.has_value());
 
-    BufferRef<int> buffer = *result;
+    BufferRef<int> buffer = *result;  // NOLINT(bugprone-unchecked-optional-access)
     ASSERT_EQ(buffer->size(), 1);
     EXPECT_EQ((*buffer)[0], 123);
 }
@@ -48,7 +48,7 @@ TEST(ObservableBuffer,Cancel) {
     try {
         deferred->await();
         FAIL() << "Expected method to throw";
-    } catch(std::runtime_error& error) {}
+    } catch(std::runtime_error& error) {}  // NOLINT(bugprone-empty-catch)
 }
 
 TEST(ObservableBuffer,Empty) {

--- a/test/cask/observable/TestObservableDistinctUntilChanged.cpp
+++ b/test/cask/observable/TestObservableDistinctUntilChanged.cpp
@@ -48,7 +48,7 @@ TEST_P(ObservableDistinctUntilChangedTest, Cancel) {
     try {
         fiber->await();
         FAIL();
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(ObservableDistinctUntilChangedTest, SequentialNumbers) {

--- a/test/cask/observable/TestObservableDistinctUntilChangedBy.cpp
+++ b/test/cask/observable/TestObservableDistinctUntilChangedBy.cpp
@@ -48,7 +48,7 @@ TEST_P(ObservableDistinctUntilChangedByTest, Cancel) {
     try {
         fiber->await();
         FAIL();
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(ObservableDistinctUntilChangedByTest, SequentialNumbers) {

--- a/test/cask/observable/TestObservableFilter.cpp
+++ b/test/cask/observable/TestObservableFilter.cpp
@@ -21,7 +21,7 @@ TEST(ObservableFilter,FilterMatch) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableFilter,FilterDoesntMatch) {
@@ -64,7 +64,7 @@ TEST(ObservableFilter,Cancelled) {
     try {
         deferred->await();
         FAIL() << "Expected method to throw";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST(ObservableFilter,StopsUpstream) {

--- a/test/cask/observable/TestObservableFlatMap.cpp
+++ b/test/cask/observable/TestObservableFlatMap.cpp
@@ -36,7 +36,7 @@ TEST(ObservableFlatMap, Pure) {
         ->await();
 
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 184.5);
+    EXPECT_EQ(*result, 184.5); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableFlatMap, UpstreamError) {

--- a/test/cask/observable/TestObservableFlatMapOptional.cpp
+++ b/test/cask/observable/TestObservableFlatMapOptional.cpp
@@ -24,7 +24,7 @@ TEST(ObservableFlatMapOptional, Value) {
     sched->run_ready_tasks();
     auto result = fiber->await();
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 1.5);
+    EXPECT_EQ(*result, 1.5); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableFlatMapOptional, UpstreamEmpty) {

--- a/test/cask/observable/TestObservableFlatScan.cpp
+++ b/test/cask/observable/TestObservableFlatScan.cpp
@@ -24,7 +24,7 @@ TEST(ObservableFlatScan, Pure) {
     auto result = fiber->await();
 
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableFlatScan, Vector) {

--- a/test/cask/observable/TestObservableFlatten.cpp
+++ b/test/cask/observable/TestObservableFlatten.cpp
@@ -20,7 +20,7 @@ TEST(ObservableFlatten, FlattensValue) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableFlatten, FlattensEmpty) {

--- a/test/cask/observable/TestObservableGuarantee.cpp
+++ b/test/cask/observable/TestObservableGuarantee.cpp
@@ -42,7 +42,7 @@ TEST_P(ObservableGuaranteeTest, RunsOnCompletion) {
         .run(sched)
         ->await();
 
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(run_count, 1);
 }
 
@@ -59,7 +59,7 @@ TEST_P(ObservableGuaranteeTest, RunsOnUpstreamComplete) {
         .run(sched)
         ->await();
 
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(run_count, 1);
 }
 

--- a/test/cask/observable/TestObservableLast.cpp
+++ b/test/cask/observable/TestObservableLast.cpp
@@ -17,6 +17,8 @@ using cask::scheduler::BenchScheduler;
 
 INSTANTIATE_SCHEDULER_TEST_BENCH_SUITE(ObservableLastTest);
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST_P(ObservableLastTest, Pure) {
     auto result = Observable<int>::pure(123)
         ->last()
@@ -118,3 +120,5 @@ TEST(ObservableLastTest, RunsCancelCallbacks) {
         EXPECT_EQ(run_count, 1);
     }
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/observable/TestObservableMap.cpp
+++ b/test/cask/observable/TestObservableMap.cpp
@@ -31,7 +31,7 @@ TEST(ObservableMap, Value) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 184.5);
+    EXPECT_EQ(*result, 184.5); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableMap, Error) {

--- a/test/cask/observable/TestObservableMapError.cpp
+++ b/test/cask/observable/TestObservableMapError.cpp
@@ -11,6 +11,8 @@ using cask::Observable;
 using cask::Scheduler;
 using cask::Task;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(ObservableMapError, Empty) {
     auto sched = Scheduler::global();
     auto result = Observable<int, std::string>::empty()
@@ -114,3 +116,5 @@ TEST(ObservableMapError, ErrorDownstream) {
     EXPECT_EQ(result, "456");
     EXPECT_EQ(counter, 1);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/observable/TestObservableMapTask.cpp
+++ b/test/cask/observable/TestObservableMapTask.cpp
@@ -35,7 +35,7 @@ TEST(ObservableMapTask, Value) {
         ->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 184.5);
+    EXPECT_EQ(*result, 184.5);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableMapTask, Error) {

--- a/test/cask/observable/TestObservableMerge.cpp
+++ b/test/cask/observable/TestObservableMerge.cpp
@@ -56,7 +56,7 @@ TEST_P(ObservableMergeTest,LeftValue) {
 
     auto result = fiber->await();
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableMergeTest,RightValue) {
@@ -67,7 +67,7 @@ TEST_P(ObservableMergeTest,RightValue) {
 
     auto result = fiber->await();
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableMergeTest,LeftError) {
@@ -103,7 +103,7 @@ TEST_P(ObservableMergeTest,Never) {
     try {
         fiber->await();
         FAIL() << "Expected fiber to cancel";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 }
 
 TEST_P(ObservableMergeTest,DownstreamLeftStop) {

--- a/test/cask/observable/TestObservableMergeAll.cpp
+++ b/test/cask/observable/TestObservableMergeAll.cpp
@@ -62,7 +62,7 @@ TEST_P(ObservableMergeAllTest,LeftValue) {
 
     auto result = fiber->await();
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableMergeAllTest,RightValue) {
@@ -75,7 +75,7 @@ TEST_P(ObservableMergeAllTest,RightValue) {
 
     auto result = fiber->await();
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_P(ObservableMergeAllTest,Never) {
@@ -102,7 +102,7 @@ TEST_P(ObservableMergeAllTest,Never) {
     try {
         fiber->await();
         FAIL() << "Expected fiber to cancel";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 }
 
 INSTANTIATE_TEST_SUITE_P(ObservableMergeAll, ObservableMergeAllTest, ::testing::Values(

--- a/test/cask/observable/TestObservableQueue.cpp
+++ b/test/cask/observable/TestObservableQueue.cpp
@@ -41,7 +41,7 @@ TEST(ObservableQueue, Value) {
     auto result = fiber->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableQueue, ValueThenError) {
@@ -238,7 +238,7 @@ TEST(ObservableQueue, TailDropOverflowStrategy) {
     auto result = fiber->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 2);
+    EXPECT_EQ(*result, 2); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableQueue, BackpressureOverflowStrategy) {
@@ -264,6 +264,6 @@ TEST(ObservableQueue, BackpressureOverflowStrategy) {
     auto result = fiber->await();
 
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 4);
+    EXPECT_EQ(*result, 4); // NOLINT(bugprone-unchecked-optional-access)
 }
 

--- a/test/cask/observable/TestObservableScan.cpp
+++ b/test/cask/observable/TestObservableScan.cpp
@@ -24,7 +24,7 @@ TEST(ObservableScan, Pure) {
     auto result = fiber->await();
 
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableScan, Vector) {

--- a/test/cask/observable/TestObservableScanTask.cpp
+++ b/test/cask/observable/TestObservableScanTask.cpp
@@ -25,7 +25,7 @@ TEST(ObservableScanTask, Pure) {
     auto result = fiber->await();
 
     EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 123);
+    EXPECT_EQ(*result, 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(ObservableScanTask, Vector) {

--- a/test/cask/observable/TestObservableSwitchMap.cpp
+++ b/test/cask/observable/TestObservableSwitchMap.cpp
@@ -53,8 +53,8 @@ TEST_P(ObservableSwitchMapTest, Pure) {
         .run(sched)
         ->await();
 
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 184.5);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 184.5);  // NOLINT(bugprone-unchecked-optional-access)
     awaitIdle();
 }
 
@@ -118,7 +118,7 @@ TEST_P(ObservableSwitchMapTest, CancelStopsInfiniteUpstream) {
     try {
         deferred->await();
         FAIL() << "Expected method to throw";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {}  // NOLINT(bugprone-empty-catch)
 
     awaitIdle();
 }

--- a/test/cask/scheduler/TestScheduler.cpp
+++ b/test/cask/scheduler/TestScheduler.cpp
@@ -4,6 +4,7 @@
 //          https://www.boost.org/LICENSE_1_0.txt)
 
 #include <atomic>
+#include <chrono>
 #include "gtest/gtest.h"
 #include "cask/Deferred.hpp"
 #include "cask/Task.hpp"

--- a/test/cask/task/TestTaskAssignment.cpp
+++ b/test/cask/task/TestTaskAssignment.cpp
@@ -10,7 +10,7 @@ using cask::Task;
 
 TEST(TaskAssignment,CopyAssignment) {
     Task<int> original = Task<int>::pure(123);
-    Task<int> other = original;
+    Task<int> other = original; // NOLINT(performance-unnecessary-copy-initialization)
     EXPECT_EQ(original.op, other.op);
 }
 
@@ -18,7 +18,7 @@ TEST(TaskAssignment,MoveAssignment) {
     Task<int> outer = Task<int>::pure(123);
 
     auto beforeResult = outer.runSync();
-    EXPECT_EQ(beforeResult->get_left(), 123);
+    EXPECT_EQ(beforeResult->get_left(), 123); // NOLINT(bugprone-unchecked-optional-access)
 
     {
         Task<int> inner = Task<int>::pure(456);
@@ -26,5 +26,5 @@ TEST(TaskAssignment,MoveAssignment) {
     }
 
     auto afterResult = outer.runSync();
-    EXPECT_EQ(afterResult->get_left(), 456);
+    EXPECT_EQ(afterResult->get_left(), 456);  // NOLINT(bugprone-unchecked-optional-access)
 }

--- a/test/cask/task/TestTaskAsyncBoundary.cpp
+++ b/test/cask/task/TestTaskAsyncBoundary.cpp
@@ -20,7 +20,7 @@ TEST(TaskAsyncBoundary, DefersExecutionToScheduler) {
     sched->run_ready_tasks();
     EXPECT_TRUE(sched->isIdle());
     EXPECT_TRUE(fiber->getValue().has_value());
-    EXPECT_EQ(*(fiber->getValue()), 123);
+    EXPECT_EQ(*(fiber->getValue()), 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskAsyncBoundary, AllowsCancelation) {

--- a/test/cask/task/TestTaskDefer.cpp
+++ b/test/cask/task/TestTaskDefer.cpp
@@ -14,8 +14,8 @@ TEST(TaskDefer,EvalutesSyncThingSync) {
     auto result = Task<int>::defer(deferred).runSync();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_TRUE(result->is_left());
-    EXPECT_EQ(result->get_left(), 123);
+    ASSERT_TRUE(result->is_left());  // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result->get_left(), 123); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskEval,EvalutesSyncThingAsync) {
@@ -32,8 +32,8 @@ TEST(TaskDefer,EvalutesErrorSync) {
     auto result = Task<int,float>::defer(deferred).runSync();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_TRUE(result->is_right());
-    EXPECT_EQ(result->get_right(), 1.23f);
+    ASSERT_TRUE(result->is_right()); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result->get_right(), 1.23f);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskDefer,EvaluatesErrorAsync) {

--- a/test/cask/task/TestTaskDeferFiber.cpp
+++ b/test/cask/task/TestTaskDeferFiber.cpp
@@ -21,7 +21,7 @@ TEST(TaskDeferFiber, PureValue) {
     sched->run_ready_tasks();
 
     ASSERT_TRUE(fiber->getValue().has_value());
-    EXPECT_EQ(*(fiber->getValue()), 123);
+    EXPECT_EQ(*(fiber->getValue()), 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskDeferFiber, Error) {
@@ -35,7 +35,7 @@ TEST(TaskDeferFiber, Error) {
     sched->run_ready_tasks();
 
     ASSERT_TRUE(fiber->getError().has_value());
-    EXPECT_EQ(*(fiber->getError()), "broke");
+    EXPECT_EQ(*(fiber->getError()), "broke");  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskDeferFiber, Cancels) {

--- a/test/cask/task/TestTaskDoOnCancel.cpp
+++ b/test/cask/task/TestTaskDoOnCancel.cpp
@@ -27,7 +27,7 @@ TEST(TaskDoOnCancel, IgnoredForCompletedValue) {
     sched->run_ready_tasks();
 
     ASSERT_TRUE(fiber->getValue().has_value());
-    EXPECT_EQ(*(fiber->getValue()), 123);
+    EXPECT_EQ(*(fiber->getValue()), 123);  // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(cancel_counter, 0);
 }
 
@@ -47,7 +47,7 @@ TEST(TaskDoOnCancel, IgnoredForCompletedError) {
     sched->run_ready_tasks();
 
     ASSERT_TRUE(fiber->getError().has_value());
-    EXPECT_EQ(*(fiber->getError()), "broke");
+    EXPECT_EQ(*(fiber->getError()), "broke");  // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(cancel_counter, 0);
 }
 

--- a/test/cask/task/TestTaskEval.cpp
+++ b/test/cask/task/TestTaskEval.cpp
@@ -13,8 +13,8 @@ TEST(TaskEval,EvalutesSync) {
     auto result = Task<int>::eval([]{ return 123; }).runSync();
     
     ASSERT_TRUE(result.has_value());
-    ASSERT_TRUE(result->is_left());
-    EXPECT_EQ(result->get_left(), 123);
+    ASSERT_TRUE(result->is_left());  // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result->get_left(), 123);  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST(TaskEval,EvaluatesAsync) {

--- a/test/cask/task/TestTaskFlatMapBoth.cpp
+++ b/test/cask/task/TestTaskFlatMapBoth.cpp
@@ -9,6 +9,8 @@
 
 using cask::Task;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskFlatMapBoth, ValueSameErrorTypes) {
     auto result = Task<int,std::string>::pure(123)
         .template flatMapBoth<float,std::string>(
@@ -128,4 +130,6 @@ TEST(TaskFlatMapBoth, ThrowsDownstreamErrorType) {
     ASSERT_TRUE(result->is_right());
     EXPECT_EQ(result->get_right().what(), std::string("thrown-error"));
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)
 

--- a/test/cask/task/TestTaskFlatMapError.cpp
+++ b/test/cask/task/TestTaskFlatMapError.cpp
@@ -10,6 +10,8 @@
 using cask::Task;
 using cask::scheduler::BenchScheduler;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskFlatMapError, PureValue) {
     auto result_opt = Task<int,std::string>::pure(123)
         .template flatMapError<std::string>([](auto) {
@@ -75,3 +77,5 @@ TEST(TaskFlatMapError, CancelsInner) {
 
     ASSERT_TRUE(fiber->isCanceled());
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/task/TestTaskGuarantee.cpp
+++ b/test/cask/task/TestTaskGuarantee.cpp
@@ -13,6 +13,8 @@ using cask::Scheduler;
 using cask::Task;
 using cask::scheduler::BenchScheduler;
 
+// NOLINTBEGIN(bugprone-empty-catch)
+
 TEST(TaskGuarantee, RunsOnComplete) {
     auto counter = 0;
     auto result = Task<int>::pure(123)
@@ -327,3 +329,5 @@ TEST(TaskGuarantee, RaceDoOnCancelInnerTask) {
     
     EXPECT_EQ(counter, 1);
 }
+
+// NOLINTEND(bugprone-empty-catch)

--- a/test/cask/task/TestTaskNever.cpp
+++ b/test/cask/task/TestTaskNever.cpp
@@ -22,6 +22,6 @@ TEST(TaskNever,EvalutesAsync) {
     try {
         deferred->await();
         FAIL() << "Excepted operation to throw.";
-    } catch(std::runtime_error& error) {}
+    } catch(std::runtime_error& error) {} // NOLINT(bugprone-empty-catch)
 }
 

--- a/test/cask/task/TestTaskNone.cpp
+++ b/test/cask/task/TestTaskNone.cpp
@@ -10,6 +10,8 @@ using cask::Task;
 using cask::Scheduler;
 using cask::None;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskNone,EvalutesSync) {
     auto result = Task<>::none().runSync();
 
@@ -25,3 +27,5 @@ TEST(TaskNone,EvaluatesAsync) {
     
     EXPECT_EQ(result, None());
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/task/TestTaskPure.cpp
+++ b/test/cask/task/TestTaskPure.cpp
@@ -9,6 +9,8 @@
 using cask::Task;
 using cask::Scheduler;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskPure,EvalutesSync) {
     auto result = Task<int>::pure(123).runSync();
 
@@ -24,3 +26,5 @@ TEST(TaskPure,EvaluatesAsync) {
     
     EXPECT_EQ(result, 123);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/task/TestTaskRace.cpp
+++ b/test/cask/task/TestTaskRace.cpp
@@ -65,7 +65,7 @@ TEST(TaskRace, Cancelled) {
     try {
         deferred->await();
         FAIL() << "Expected method to throw.";
-    } catch(std::runtime_error&) {}
+    } catch(std::runtime_error&) {} // NOLINT(bugprone-empty-catch)
 }
 
 TEST(TaskRace, TaskStressTest) {

--- a/test/cask/task/TestTaskRaiseError.cpp
+++ b/test/cask/task/TestTaskRaiseError.cpp
@@ -9,6 +9,8 @@
 using cask::Task;
 using cask::Scheduler;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskRaiseError,EvalutesSync) {
     auto result = Task<int,float>::raiseError(1.23).runSync();
 
@@ -28,3 +30,5 @@ TEST(TaskRaiseError,EvaluatesAsync) {
         EXPECT_EQ(error, 1.23f);
     }
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/test/cask/task/TestTaskRecover.cpp
+++ b/test/cask/task/TestTaskRecover.cpp
@@ -10,6 +10,8 @@
 using cask::Task;
 using cask::scheduler::BenchScheduler;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST(TaskRecover, PureValue) {
     auto result_opt = Task<int,std::string>::pure(123)
         .recover([](auto) {
@@ -54,3 +56,5 @@ TEST(TaskRecover, Canceled) {
         SUCCEED();
     }
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)


### PR DESCRIPTION
The ubuntu 20.04 runners are going EOL. This change removes those runners from cask's CI infrastructure.

That means the analyze step in CI needs to run on Ubuntu 24.04 which pulls in a new clang-tidy. This resolves the relevant issues found in that newer version.