### PR TITLE
fix: allocate chunks faster, fix chunk size calc

### DIFF
--- a/bench/BenchPool.cpp
+++ b/bench/BenchPool.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <thread>
 #include <vector>
 #include "cask/Pool.hpp"
 
@@ -70,7 +71,10 @@ BENCHMARK(BM_Pool_ColdStart);
 
 // Multi-threaded alloc/dealloc on a shared pool.
 static void BM_Pool_Contended(benchmark::State& state) {
-    Pool pool;
+
+    // This pool is static because it is intended to be used across all benchmark
+    // threads. This is an intentional part of the benchmark.
+    static Pool pool;
 
     // Pre-warm
     if (state.thread_index() == 0) {

--- a/bench/BenchPool.cpp
+++ b/bench/BenchPool.cpp
@@ -1,5 +1,4 @@
 #include <benchmark/benchmark.h>
-#include <thread>
 #include <vector>
 #include "cask/Pool.hpp"
 
@@ -71,7 +70,7 @@ BENCHMARK(BM_Pool_ColdStart);
 
 // Multi-threaded alloc/dealloc on a shared pool.
 static void BM_Pool_Contended(benchmark::State& state) {
-    static Pool pool;
+    Pool pool;
 
     // Pre-warm
     if (state.thread_index() == 0) {

--- a/bench/BenchPool.cpp
+++ b/bench/BenchPool.cpp
@@ -1,0 +1,98 @@
+#include <benchmark/benchmark.h>
+#include <thread>
+#include <vector>
+#include "cask/Pool.hpp"
+
+using cask::Pool;
+
+struct SmallObj { char data[32]; };
+struct MediumObj { char data[128]; };
+struct LargeObj { char data[256]; };
+struct XLargeObj { char data[512]; };
+struct XXLargeObj { char data[1024]; };
+struct XXXLargeObj { char data[2048]; };
+struct XXXXLargeObj { char data[4096]; };
+
+// Steady-state single alloc/dealloc cycle on a pre-warmed pool.
+// Parameterized by object size to cover each pool tier.
+template <typename T>
+static void BM_Pool_AllocDealloc(benchmark::State& state) {
+    Pool pool;
+    // Pre-warm
+    T* warm = pool.allocate<T>();
+    pool.deallocate<T>(warm);
+
+    for (auto _ : state) {
+        T* ptr = pool.allocate<T>();
+        benchmark::DoNotOptimize(ptr);
+        pool.deallocate<T>(ptr);
+    }
+}
+BENCHMARK(BM_Pool_AllocDealloc<SmallObj>);
+BENCHMARK(BM_Pool_AllocDealloc<MediumObj>);
+BENCHMARK(BM_Pool_AllocDealloc<LargeObj>);
+BENCHMARK(BM_Pool_AllocDealloc<XLargeObj>);
+BENCHMARK(BM_Pool_AllocDealloc<XXLargeObj>);
+BENCHMARK(BM_Pool_AllocDealloc<XXXLargeObj>);
+BENCHMARK(BM_Pool_AllocDealloc<XXXXLargeObj>);
+
+// Allocate N objects without freeing, then free all.
+// Stresses chunk allocation when free list empties.
+static void BM_Pool_BurstAlloc(benchmark::State& state) {
+    auto N = static_cast<std::size_t>(state.range(0));
+
+    for (auto _ : state) {
+        Pool pool;
+        std::vector<SmallObj*> ptrs;
+        ptrs.reserve(N);
+
+        for (std::size_t i = 0; i < N; i++) {
+            ptrs.push_back(pool.allocate<SmallObj>());
+        }
+        benchmark::DoNotOptimize(ptrs.data());
+
+        for (auto* ptr : ptrs) {
+            pool.deallocate<SmallObj>(ptr);
+        }
+    }
+}
+BENCHMARK(BM_Pool_BurstAlloc)->Range(64, 8192);
+
+// First allocation from a fresh Pool, measuring chunk allocation cost directly.
+static void BM_Pool_ColdStart(benchmark::State& state) {
+    for (auto _ : state) {
+        Pool pool;
+        SmallObj* ptr = pool.allocate<SmallObj>();
+        benchmark::DoNotOptimize(ptr);
+        pool.deallocate<SmallObj>(ptr);
+    }
+}
+BENCHMARK(BM_Pool_ColdStart);
+
+// Multi-threaded alloc/dealloc on a shared pool.
+static void BM_Pool_Contended(benchmark::State& state) {
+    static Pool pool;
+
+    // Pre-warm
+    if (state.thread_index() == 0) {
+        SmallObj* warm = pool.allocate<SmallObj>();
+        pool.deallocate<SmallObj>(warm);
+    }
+
+    for (auto _ : state) {
+        SmallObj* ptr = pool.allocate<SmallObj>();
+        benchmark::DoNotOptimize(ptr);
+        pool.deallocate<SmallObj>(ptr);
+    }
+}
+BENCHMARK(BM_Pool_Contended)->Threads(1)->Threads(2)->Threads(4)->Threads(8);
+
+// new/delete baseline for comparison.
+static void BM_Pool_NewDelete_Baseline(benchmark::State& state) {
+    for (auto _ : state) {
+        auto* ptr = new SmallObj();
+        benchmark::DoNotOptimize(ptr);
+        delete ptr;
+    }
+}
+BENCHMARK(BM_Pool_NewDelete_Baseline);

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -4,6 +4,7 @@ if get_option('build_benchmarks')
     bench_sources = [
         'BenchErased.cpp',
         'BenchFlatMap.cpp',
+        'BenchPool.cpp',
         'main.cpp'
     ]
 

--- a/include/cask/Pool.hpp
+++ b/include/cask/Pool.hpp
@@ -18,16 +18,15 @@ public:
     void deallocate(T* ptr);
 
 private:
-    static constexpr std::size_t smallest_block_num_entries = config::initial_blocks_per_pool;
-    static constexpr std::size_t smallest_block_size = config::cache_line_size * smallest_block_num_entries;
+    static constexpr std::size_t num_blocks = config::initial_blocks_per_pool;
 
-    pool::BlockPool<config::cache_line_size, smallest_block_size, alignof(std::max_align_t)> small_pool;
-    pool::BlockPool<config::cache_line_size*2UL, smallest_block_size / 2, alignof(std::max_align_t)> medium_pool;
-    pool::BlockPool<config::cache_line_size*4UL, smallest_block_size / 4, alignof(std::max_align_t)> large_pool;
-    pool::BlockPool<config::cache_line_size*8UL, smallest_block_size / 8, alignof(std::max_align_t)> xlarge_pool;
-    pool::BlockPool<config::cache_line_size*16UL, smallest_block_size / 16, alignof(std::max_align_t)> xxlarge_pool;
-    pool::BlockPool<config::cache_line_size*32UL, smallest_block_size / 32, alignof(std::max_align_t)> xxxlarge_pool;
-    pool::BlockPool<config::cache_line_size*64UL, smallest_block_size / 64, alignof(std::max_align_t)> xxxxlarge_pool;
+    pool::BlockPool<config::cache_line_size,      num_blocks,      alignof(std::max_align_t)> small_pool;
+    pool::BlockPool<config::cache_line_size*2UL,  num_blocks/2,    alignof(std::max_align_t)> medium_pool;
+    pool::BlockPool<config::cache_line_size*4UL,  num_blocks/4,    alignof(std::max_align_t)> large_pool;
+    pool::BlockPool<config::cache_line_size*8UL,  num_blocks/8,    alignof(std::max_align_t)> xlarge_pool;
+    pool::BlockPool<config::cache_line_size*16UL, num_blocks/16,   alignof(std::max_align_t)> xxlarge_pool;
+    pool::BlockPool<config::cache_line_size*32UL, num_blocks/32,   alignof(std::max_align_t)> xxxlarge_pool;
+    pool::BlockPool<config::cache_line_size*64UL, num_blocks/64,   alignof(std::max_align_t)> xxxxlarge_pool;
 };
 
 template <class T, class... Args>

--- a/include/cask/pool/BlockPool.hpp
+++ b/include/cask/pool/BlockPool.hpp
@@ -183,15 +183,15 @@ void BlockPool<BlockSize,NumBlocksInChunk,Alignment>::allocate_chunk() {
             } while(!allocated_chunks.compare_exchange_weak(old_head,new_head,std::memory_order_release,std::memory_order_relaxed));
         }
 
-	// String the chunk into a list of blocks that can be pushed onto
-	// the free list
+        // String the chunk into a list of blocks that can be pushed onto
+        // the free list
         for (std::size_t i = 0; i < NumBlocksInChunk; i++) {
             Block* block = &(chunk->blocks[i]);
             block->next = (i < NumBlocksInChunk - 1) ? &(chunk->blocks[i + 1]) : nullptr;
             POISON_BLOCK(block);
         }
 
-	// Push the entire chunk onto the free list with a single CAS
+        // Push the entire chunk onto the free list with a single CAS
         Head<Block> old_head = free_blocks.load(std::memory_order_relaxed);
         Head<Block> new_head;
         do {

--- a/include/cask/pool/BlockPool.hpp
+++ b/include/cask/pool/BlockPool.hpp
@@ -65,6 +65,8 @@ private:
     // compile errors about 0-sized arrays.
     typedef typename std::conditional<PadSize == 0, BlockWithoutPad, BlockWithPad>::type Block;
 
+    static_assert(BlockSize > 0);
+    static_assert(NumBlocksInChunk > 0);
     static_assert(sizeof(Block) == TotalBlockSize + PadSize);
     static_assert(offsetof(Block, memory) == 0);
 


### PR DESCRIPTION
This change improves the performance of the memory pool by making two important changes.

First, the math for choosing the initial pool sizes has been fixed. Previously `Pool` computed the `byte size` of a chunk while `BlockPool` was expecting to be passed the number of blocks within a chunk. This would lead to massive over-allocation at the start of a pool.

Second, this change massively speeds up allocation of new chunks leading to less stalling. It does this by prebuilding the list of new chunks locally and then performing a single CAS to push the blocks on the free list. Previously it performed an atomic CAS per-block which meant lots of memory barriers and possible stalling as we built up the free list.