### PR TITLE
fix: use an atomic bool for should_run

### DIFF
--- a/include/cask/scheduler/SingleThreadScheduler.hpp
+++ b/include/cask/scheduler/SingleThreadScheduler.hpp
@@ -121,7 +121,7 @@ private:
         std::atomic_bool thread_running;
         ThreadStartBarrier start_barrier; 
 
-        bool should_run;
+        std::atomic_bool should_run;
         std::atomic_bool idle;
         ReadyQueue ready_queue;
 

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -100,7 +100,7 @@ void SingleThreadScheduler::try_wake() {
 
 void SingleThreadScheduler::stop() {
     // Indicate that the run thread should shut down
-    control_data->should_run = false;
+    control_data->should_run.store(false, std::memory_order_release);
     control_data->ready_queue.wake();
 
     // Wait for the run thread to finish - unless the destructor
@@ -183,7 +183,7 @@ void SingleThreadScheduler::run(const std::shared_ptr<SchedulerControlData>& con
 
     while(true) {
         // Check if we should be shutting down
-        if (!control_data->should_run) break;
+        if (!control_data->should_run.load(std::memory_order_acquire)) break;
 
         // Evaluate any expired timers
         {

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -100,7 +100,7 @@ void SingleThreadScheduler::try_wake() {
 
 void SingleThreadScheduler::stop() {
     // Indicate that the run thread should shut down
-    control_data->should_run.store(false, std::memory_order_release);
+    control_data->should_run.store(false, std::memory_order_relaxed);
     control_data->ready_queue.wake();
 
     // Wait for the run thread to finish - unless the destructor
@@ -183,7 +183,7 @@ void SingleThreadScheduler::run(const std::shared_ptr<SchedulerControlData>& con
 
     while(true) {
         // Check if we should be shutting down
-        if (!control_data->should_run.load(std::memory_order_acquire)) break;
+        if (!control_data->should_run.load(std::memory_order_relaxed)) break;
 
         // Evaluate any expired timers
         {


### PR DESCRIPTION
This resolves some undefined behavior related to the should_run flag which was expected to be atomic - and likely was on platforms with strong memory ordering - but wasn't codified as such.