### PR TITLE
chore: update to use all the latest CI runners

### DIFF
--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -151,7 +151,7 @@ jobs:
     - name: Install Python Development Dependencies
       run: python3 -m pip install meson==1.10.1 ninja
     - name: Generate the Build Environment
-      run: meson setup builddir --cross-file=build_windows_arm_cross_file.txt
+      run: meson setup builddir
     - name: Compile
       working-directory: builddir
       run: meson compile

--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
         target: [debug, release, release_no_atomics, release_forced_cede_disabled, clang, mips, arm]
       fail-fast: false
 
@@ -65,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-14]
+        os: [macos-14, macos-15, macos-26, macos-15-intel, macos-26-intel]
         target: [clang]
       fail-fast: false
 
@@ -103,7 +103,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025, windows-11-arm]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cask.yml
+++ b/.github/workflows/cask.yml
@@ -103,7 +103,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022, windows-2025, windows-11-arm]
+        os: [windows-2022, windows-2025]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -125,6 +125,33 @@ jobs:
       run: python3 -m pip install meson==1.10.1 ninja
     - name: Generate the Build Environment
       run: meson setup builddir
+    - name: Compile
+      working-directory: builddir
+      run: meson compile
+  
+  build-windows-arm:
+    name: Windows ARM
+    if: github.actor != 'engineering-at-tangotango'
+
+    runs-on: windows-11-arm
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+        token: ${{ github.token }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Prepare MSVC
+      uses: bus1/cabuild/action/msdevshell@v1
+      with:
+        architecture: arm64
+    - name: Install Python Development Dependencies
+      run: python3 -m pip install meson==1.10.1 ninja
+    - name: Generate the Build Environment
+      run: meson setup builddir --cross-file=build_windows_arm_cross_file.txt
     - name: Compile
       working-directory: builddir
       run: meson compile


### PR DESCRIPTION
Cask CI is meant to run on as many platforms as possible to ensure wide compatibility. This change just updates the runner matrix to run on all the latest github-hosted options and remove the now-defunction `windows-2019` target.