### PR TITLE
fix: avoid UB during multi-threaded global pool init

### DIFF
--- a/bench/BenchFlatMap.cpp
+++ b/bench/BenchFlatMap.cpp
@@ -215,8 +215,7 @@ static void BM_GlobalPool(benchmark::State& state) {
         benchmark::DoNotOptimize(pool);
     }
 }
-BENCHMARK(BM_GlobalPool);
-BENCHMARK(BM_GlobalPool)->ThreadRange(2, 8);
+BENCHMARK(BM_GlobalPool)->ThreadRange(1, 8);
 
 // Benchmark pool allocation
 static void BM_PoolAllocate(benchmark::State& state) {

--- a/bench/BenchFlatMap.cpp
+++ b/bench/BenchFlatMap.cpp
@@ -216,6 +216,7 @@ static void BM_GlobalPool(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_GlobalPool);
+BENCHMARK(BM_GlobalPool)->ThreadRange(2, 8);
 
 // Benchmark pool allocation
 static void BM_PoolAllocate(benchmark::State& state) {

--- a/src/cask/pool/InternalPool.cpp
+++ b/src/cask/pool/InternalPool.cpp
@@ -1,5 +1,34 @@
 #include "cask/pool/InternalPool.hpp"
 
+namespace {
+
+// RAII spinlock guard: acquires the flag on construction and releases it
+// on destruction, ensuring the lock is dropped on every exit path -
+// including if an exception is thrown while the lock is held.
+class SpinlockGuard {
+public:
+    explicit SpinlockGuard(std::atomic_flag& flag) : flag(flag) {
+        while (flag.test_and_set(std::memory_order_acquire)) {
+            #if defined(__cpp_lib_atomic_flag_test)
+            while (flag.test(std::memory_order_relaxed))
+            #endif
+            ;
+        }
+    }
+
+    ~SpinlockGuard() {
+        flag.clear(std::memory_order_release);
+    }
+
+    SpinlockGuard(const SpinlockGuard&) = delete;
+    SpinlockGuard& operator=(const SpinlockGuard&) = delete;
+
+private:
+    std::atomic_flag& flag;
+};
+
+} // namespace
+
 std::shared_ptr<cask::Pool> cask::pool::global_pool() {
     static std::atomic_flag initializing_pool = ATOMIC_FLAG_INIT;
     static std::weak_ptr<cask::Pool> pool_weak;
@@ -17,22 +46,7 @@ std::shared_ptr<cask::Pool> cask::pool::global_pool() {
     // Slow path: the spinlock must be held for *all* access to pool_weak.
     // Calling weak_ptr::lock() concurrently with an assignment to the same
     // weak_ptr is a data race - so an unguarded read of it is not safe.
-    while(initializing_pool.test_and_set(std::memory_order_acquire)) {
-        #if defined(__cpp_lib_atomic_flag_test)
-        while (initializing_pool.test(std::memory_order_relaxed))
-        #endif
-        ;
-    }
-
-    // RAII guard ensures the spinlock is released on every exit path,
-    // including if Pool construction throws below.
-    struct SpinlockGuard {
-        explicit SpinlockGuard(std::atomic_flag& flag_ref) : flag(flag_ref) {}
-        SpinlockGuard(const SpinlockGuard&) = delete;
-        SpinlockGuard& operator=(const SpinlockGuard&) = delete;
-        ~SpinlockGuard() { flag.clear(std::memory_order_release); }
-        std::atomic_flag& flag;
-    } guard{initializing_pool};
+    SpinlockGuard guard(initializing_pool);
 
     auto pool = pool_weak.lock();
     if (!pool) {

--- a/src/cask/pool/InternalPool.cpp
+++ b/src/cask/pool/InternalPool.cpp
@@ -4,24 +4,34 @@ std::shared_ptr<cask::Pool> cask::pool::global_pool() {
     static std::atomic_flag initializing_pool = ATOMIC_FLAG_INIT;
     static std::weak_ptr<cask::Pool> pool_weak;
 
-    if (auto pool = pool_weak.lock()) {
-        return pool;
-    } else {
-        while(initializing_pool.test_and_set(std::memory_order_acquire)) {
-            #if defined(__cpp_lib_atomic_flag_test)
-            while (initializing_pool.test(std::memory_order_relaxed))
-            #endif
-            ;
-        }
+    // Fast path: a thread-local cache of the global weak pointer. Only this
+    // thread touches local_pool_weak so calling lock() on it cannot race. It
+    // also doesn't extend the pool's lifetime - when the pool is destroyed
+    // this cache expires and we fall through to the slow path below.
+    thread_local std::weak_ptr<cask::Pool> local_pool_weak;
 
-        if (auto pool = pool_weak.lock()) {
-            initializing_pool.clear(std::memory_order_release);
-            return pool;
-        } else {
-            pool = std::make_shared<cask::Pool>();
-            pool_weak = pool;
-            initializing_pool.clear(std::memory_order_release);
-            return pool;
-        }
+    if (auto pool = local_pool_weak.lock()) {
+        return pool;
     }
+
+    // Slow path: the spinlock must be held for *all* access to pool_weak.
+    // Calling weak_ptr::lock() concurrently with an assignment to the same
+    // weak_ptr is a data race - so an unguarded read of it is not safe.
+    while(initializing_pool.test_and_set(std::memory_order_acquire)) {
+        #if defined(__cpp_lib_atomic_flag_test)
+        while (initializing_pool.test(std::memory_order_relaxed))
+        #endif
+        ;
+    }
+
+    auto pool = pool_weak.lock();
+    if (!pool) {
+        pool = std::make_shared<cask::Pool>();
+        pool_weak = pool;
+    }
+
+    initializing_pool.clear(std::memory_order_release);
+
+    local_pool_weak = pool;
+    return pool;
 }

--- a/src/cask/pool/InternalPool.cpp
+++ b/src/cask/pool/InternalPool.cpp
@@ -45,13 +45,18 @@ std::shared_ptr<cask::Pool> cask::pool::global_pool() {
 
     // Slow path: the spinlock must be held for *all* access to pool_weak.
     // Calling weak_ptr::lock() concurrently with an assignment to the same
-    // weak_ptr is a data race - so an unguarded read of it is not safe.
-    SpinlockGuard guard(initializing_pool);
+    // weak_ptr is a data race - so an unguarded read of it is not safe. The
+    // guard lives in an explicit scope so the lock is acquired and released
+    // exactly here - keeping it off the fast path above.
+    std::shared_ptr<cask::Pool> pool;
+    {
+        SpinlockGuard guard(initializing_pool);
 
-    auto pool = pool_weak.lock();
-    if (!pool) {
-        pool = std::make_shared<cask::Pool>();
-        pool_weak = pool;
+        pool = pool_weak.lock();
+        if (!pool) {
+            pool = std::make_shared<cask::Pool>();
+            pool_weak = pool;
+        }
     }
 
     local_pool_weak = pool;

--- a/src/cask/pool/InternalPool.cpp
+++ b/src/cask/pool/InternalPool.cpp
@@ -27,8 +27,11 @@ std::shared_ptr<cask::Pool> cask::pool::global_pool() {
     // RAII guard ensures the spinlock is released on every exit path,
     // including if Pool construction throws below.
     struct SpinlockGuard {
-        std::atomic_flag& flag;
+        explicit SpinlockGuard(std::atomic_flag& flag_ref) : flag(flag_ref) {}
+        SpinlockGuard(const SpinlockGuard&) = delete;
+        SpinlockGuard& operator=(const SpinlockGuard&) = delete;
         ~SpinlockGuard() { flag.clear(std::memory_order_release); }
+        std::atomic_flag& flag;
     } guard{initializing_pool};
 
     auto pool = pool_weak.lock();

--- a/src/cask/pool/InternalPool.cpp
+++ b/src/cask/pool/InternalPool.cpp
@@ -24,13 +24,18 @@ std::shared_ptr<cask::Pool> cask::pool::global_pool() {
         ;
     }
 
+    // RAII guard ensures the spinlock is released on every exit path,
+    // including if Pool construction throws below.
+    struct SpinlockGuard {
+        std::atomic_flag& flag;
+        ~SpinlockGuard() { flag.clear(std::memory_order_release); }
+    } guard{initializing_pool};
+
     auto pool = pool_weak.lock();
     if (!pool) {
         pool = std::make_shared<cask::Pool>();
         pool_weak = pool;
     }
-
-    initializing_pool.clear(std::memory_order_release);
 
     local_pool_weak = pool;
     return pool;


### PR DESCRIPTION
This change avoids undefined behavior in multi-threaded situations where intializing a global pool while racing with other initializers could result in issues. Calling lock on an initialized weak pointer is safe, but the act of constructing and mutating the reference is not.

This change uses a spinlock to prevent this situation from occuring. To keep performance high, it utilizes a thread-local cache of the weak pointer so that the fast path doesn't engage that spinlock after the first access of the global pool on a given thread.