### PR TITLE
fix: safer await blocking

### DIFF
--- a/include/cask/deferred/PromiseDeferred.hpp
+++ b/include/cask/deferred/PromiseDeferred.hpp
@@ -18,19 +18,6 @@
 
 namespace cask::deferred {
 
-template <class T, class E>
-class PromiseDeferred;
-
-template <class T, class E>
-struct PromiseAwaitState {
-    std::mutex mutex;
-    std::condition_variable cond;
-    bool finished = false;
-    bool canceled = false;
-    std::optional<Either<T,E>> result;
-};
-
-
 template <class T, class E = std::any>
 class PromiseDeferred final : public Deferred<T,E> {
 public:
@@ -46,6 +33,14 @@ public:
 
     std::shared_ptr<Promise<T,E>> promise;
 private:
+    struct AwaitState {
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool finished = false;
+        bool canceled = false;
+        std::optional<Either<T,E>> result;
+    };
+
     std::shared_ptr<Scheduler> sched;
 };
 
@@ -99,8 +94,8 @@ T PromiseDeferred<T,E>::await() {
     std::optional<Either<T,E>> result = promise->get();
 
     if(!result.has_value()) {
-        auto await_state = std::make_shared<PromiseAwaitState<T,E>>();
-        std::weak_ptr<PromiseAwaitState<T,E>> weak_state = await_state;
+        auto await_state = std::make_shared<AwaitState>();
+        std::weak_ptr<AwaitState> weak_state = await_state;
 
         // Capture only a weak_ptr so the await state is released as soon as
         // await() returns, even though the stored callbacks outlive this call.

--- a/include/cask/deferred/PromiseDeferred.hpp
+++ b/include/cask/deferred/PromiseDeferred.hpp
@@ -7,6 +7,7 @@
 #define _CASK_PROMISE_DEFERRED_H_
 
 #include <any>
+#include <condition_variable>
 #include <functional>
 #include <optional>
 #include <memory>
@@ -19,6 +20,15 @@ namespace cask::deferred {
 
 template <class T, class E>
 class PromiseDeferred;
+
+template <class T, class E>
+struct PromiseAwaitState {
+    std::mutex mutex;
+    std::condition_variable cond;
+    bool finished = false;
+    bool canceled = false;
+    std::optional<Either<T,E>> result;
+};
 
 
 template <class T, class E = std::any>
@@ -89,20 +99,38 @@ T PromiseDeferred<T,E>::await() {
     std::optional<Either<T,E>> result = promise->get();
 
     if(!result.has_value()) {
-        std::shared_ptr<std::mutex> mutex = std::make_shared<std::mutex>();
-        mutex->lock();
+        auto await_state = std::make_shared<PromiseAwaitState<T,E>>();
+        std::weak_ptr<PromiseAwaitState<T,E>> weak_state = await_state;
 
-        promise->onComplete([mutex, &result](Either<T,E> newResult){
-            result = newResult;
-            mutex->unlock();
+        // Capture only a weak_ptr so the await state is released as soon as
+        // await() returns, even though the stored callbacks outlive this call.
+        promise->onComplete([weak_state](Either<T,E> newResult){
+            if(auto state = weak_state.lock()) {
+                {
+                    std::lock_guard<std::mutex> guard(state->mutex);
+                    state->result = newResult;
+                    state->finished = true;
+                }
+                state->cond.notify_all();
+            }
         });
 
-        promise->onCancel([mutex, &canceled](){
-            canceled = true;
-            mutex->unlock();
+        promise->onCancel([weak_state](){
+            if(auto state = weak_state.lock()) {
+                {
+                    std::lock_guard<std::mutex> guard(state->mutex);
+                    state->canceled = true;
+                    state->finished = true;
+                }
+                state->cond.notify_all();
+            }
         });
 
-        mutex->lock();
+        std::unique_lock<std::mutex> lock(await_state->mutex);
+        await_state->cond.wait(lock, [&await_state]{ return await_state->finished; });
+
+        result = std::move(await_state->result);
+        canceled = await_state->canceled;
     }
 
     if(canceled) {

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <climits>
+#include <condition_variable>
 #include <mutex>
 #include <map>
 #include <stack>
@@ -750,14 +751,20 @@ T FiberImpl<T,E>::await() {
     auto current_state = state.load(std::memory_order_acquire);
 
     if(current_state != COMPLETED && current_state != CANCELED) {
-        std::shared_ptr<std::mutex> mutex = std::make_shared<std::mutex>();
-        mutex->lock();
+        auto mutex = std::make_shared<std::mutex>();
+        auto cond = std::make_shared<std::condition_variable>();
+        auto finished = std::make_shared<bool>(false);
 
-        onFiberShutdown([mutex](auto){
-            mutex->unlock();
+        onFiberShutdown([mutex, cond, finished](auto){
+            {
+                std::lock_guard<std::mutex> guard(*mutex);
+                *finished = true;
+            }
+            cond->notify_all();
         });
 
-        mutex->lock();
+        std::unique_lock<std::mutex> lock(*mutex);
+        cond->wait(lock, [&finished]{ return *finished; });
     }
 
     if(auto value_opt = value.getValue()) {

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -22,6 +22,12 @@ namespace cask::fiber {
 
 enum FiberState : std::uint8_t { READY, RUNNING, WAITING, DELAYED, RACING, COMPLETED, CANCELED };
 
+struct FiberAwaitState {
+    std::mutex mutex;
+    std::condition_variable cond;
+    bool finished = false;
+};
+
 constexpr const char * print_state(const FiberState& state) {
     return state == READY ? "READY" :
            state == RUNNING ? "RUNNING" :
@@ -751,20 +757,22 @@ T FiberImpl<T,E>::await() {
     auto current_state = state.load(std::memory_order_acquire);
 
     if(current_state != COMPLETED && current_state != CANCELED) {
-        auto mutex = std::make_shared<std::mutex>();
-        auto cond = std::make_shared<std::condition_variable>();
-        auto finished = std::make_shared<bool>(false);
+        auto await_state = std::make_shared<FiberAwaitState>();
 
-        onFiberShutdown([mutex, cond, finished](auto){
-            {
-                std::lock_guard<std::mutex> guard(*mutex);
-                *finished = true;
+        // Capture only a weak_ptr so the await state is released as soon as
+        // await() returns, even though the stored callback outlives this call.
+        onFiberShutdown([weak_state = std::weak_ptr<FiberAwaitState>(await_state)](auto){
+            if(auto state = weak_state.lock()) {
+                {
+                    std::lock_guard<std::mutex> guard(state->mutex);
+                    state->finished = true;
+                }
+                state->cond.notify_all();
             }
-            cond->notify_all();
         });
 
-        std::unique_lock<std::mutex> lock(*mutex);
-        cond->wait(lock, [&finished]{ return *finished; });
+        std::unique_lock<std::mutex> lock(await_state->mutex);
+        await_state->cond.wait(lock, [&await_state]{ return await_state->finished; });
     }
 
     if(auto value_opt = value.getValue()) {

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -762,12 +762,12 @@ T FiberImpl<T,E>::await() {
         // Capture only a weak_ptr so the await state is released as soon as
         // await() returns, even though the stored callback outlives this call.
         onFiberShutdown([weak_state = std::weak_ptr<AwaitState>(await_state)](auto){
-            if(auto state = weak_state.lock()) {
+            if(auto await_state_locked = weak_state.lock()) {
                 {
-                    std::lock_guard<std::mutex> guard(state->mutex);
-                    state->finished = true;
+                    std::lock_guard<std::mutex> guard(await_state_locked->mutex);
+                    await_state_locked->finished = true;
                 }
-                state->cond.notify_all();
+                await_state_locked->cond.notify_all();
             }
         });
 

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -22,12 +22,6 @@ namespace cask::fiber {
 
 enum FiberState : std::uint8_t { READY, RUNNING, WAITING, DELAYED, RACING, COMPLETED, CANCELED };
 
-struct FiberAwaitState {
-    std::mutex mutex;
-    std::condition_variable cond;
-    bool finished = false;
-};
-
 constexpr const char * print_state(const FiberState& state) {
     return state == READY ? "READY" :
            state == RUNNING ? "RUNNING" :
@@ -57,6 +51,12 @@ public:
     T await() override;
 
 private:
+    struct AwaitState {
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool finished = false;
+    };
+
     friend class Fiber<T,E>;
 
     template <class TT, class EE>
@@ -757,11 +757,11 @@ T FiberImpl<T,E>::await() {
     auto current_state = state.load(std::memory_order_acquire);
 
     if(current_state != COMPLETED && current_state != CANCELED) {
-        auto await_state = std::make_shared<FiberAwaitState>();
+        auto await_state = std::make_shared<AwaitState>();
 
         // Capture only a weak_ptr so the await state is released as soon as
         // await() returns, even though the stored callback outlives this call.
-        onFiberShutdown([weak_state = std::weak_ptr<FiberAwaitState>(await_state)](auto){
+        onFiberShutdown([weak_state = std::weak_ptr<AwaitState>(await_state)](auto){
             if(auto state = weak_state.lock()) {
                 {
                     std::lock_guard<std::mutex> guard(state->mutex);


### PR DESCRIPTION
This change updates the await implementation to use a safer and more correct approach utilizing a lock and a condition variable. The previous approach relied on significant undefined behavior to properly function, and likely wasn't correct across all platforms.