### PR TITLE
fix: don't leak run thread when stopping an unstarted sched

### DIFF
--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -91,7 +91,15 @@ SingleThreadScheduler::~SingleThreadScheduler() {
 
 void SingleThreadScheduler::start() {
     control_data->start_barrier.notify();
-    while(!control_data->thread_running.load(std::memory_order_acquire));
+
+    // Wait for the run thread to indicate it is running. If shutdown has
+    // been requested the run thread may exit without ever setting
+    // thread_running - so stop waiting in that case rather than spin forever.
+    while(!control_data->thread_running.load(std::memory_order_acquire)) {
+        if (!control_data->should_run.load(std::memory_order_relaxed)) {
+            break;
+        }
+    }
 }
 
 void SingleThreadScheduler::try_wake() {

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -101,6 +101,10 @@ void SingleThreadScheduler::try_wake() {
 void SingleThreadScheduler::stop() {
     // Indicate that the run thread should shut down
     control_data->should_run.store(false, std::memory_order_relaxed);
+
+    // Release the run thread if it is still waiting to be started so that
+    // it can observe the shutdown request and exit rather than leak.
+    control_data->start_barrier.notify();
     control_data->ready_queue.wake();
 
     // Wait for the run thread to finish - unless the destructor
@@ -177,6 +181,12 @@ void SingleThreadScheduler::run(const std::shared_ptr<SchedulerControlData>& con
 
     // Wait for the signal that the scheduler is ready to run
     control_data->start_barrier.wait();
+
+    // If shutdown was requested before the scheduler ever started, exit
+    // immediately without ever indicating that the thread is running.
+    if (!control_data->should_run.load(std::memory_order_relaxed)) {
+        return;
+    }
 
     // We've been told to start running
     control_data->thread_running.store(true, std::memory_order_release);

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -1,0 +1,97 @@
+//          Copyright Tango Tango, Inc. 2020 - 2025.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <thread>
+#include "gtest/gtest.h"
+#include "cask/scheduler/SingleThreadScheduler.hpp"
+
+using cask::scheduler::SingleThreadScheduler;
+
+TEST(SingleThreadSchedulerTest, StopsCleanlyWhenNeverStarted) {
+    // A scheduler constructed with DisableAutoStart that is never started
+    // must still shut down cleanly (and not leak its run thread) when
+    // destructed.
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
+
+    sched.reset();
+}
+
+TEST(SingleThreadSchedulerTest, ExplicitStopWhenNeverStarted) {
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
+
+    sched->stop();
+    sched.reset();
+}
+
+TEST(SingleThreadSchedulerTest, ReleasesRunThreadWhenNeverStarted) {
+    // The run thread holds a reference to the scheduler's internal control
+    // data (which owns the callbacks given here). If the scheduler is
+    // destructed without ever being started, the run thread must still be
+    // woken so it can exit and release that reference rather than leak.
+    auto sentinel = std::make_shared<int>(0);
+    std::weak_ptr<int> watcher = sentinel;
+
+    {
+        auto sched = std::make_unique<SingleThreadScheduler>(
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            [sentinel](){},
+            [](){},
+            [](auto&){},
+            [](auto&){},
+            cask::scheduler::DisableAutoStart);
+
+        sentinel.reset();
+    }
+
+    // After destruction the run thread is the only remaining owner of the
+    // sentinel. Wait for it to exit and drop its reference.
+    bool released = false;
+    for (int i = 0; i < 1000; i++) {
+        if (watcher.expired()) {
+            released = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    EXPECT_TRUE(released);
+}
+
+TEST(SingleThreadSchedulerTest, StartsAndStops) {
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
+
+    sched->start();
+    sched->stop();
+    sched.reset();
+}

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -80,6 +80,25 @@ TEST(SingleThreadSchedulerTest, ReleasesRunThreadWhenNeverStarted) {
     EXPECT_TRUE(released);
 }
 
+TEST(SingleThreadSchedulerTest, StartAfterStopDoesNotHang) {
+    // If stop() runs before start(), the run thread exits without ever
+    // setting thread_running. A subsequent start() must observe the
+    // shutdown and return rather than spin forever.
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
+
+    sched->stop();
+    sched->start();
+    sched.reset();
+}
+
 TEST(SingleThreadSchedulerTest, StartsAndStops) {
     auto sched = std::make_unique<SingleThreadScheduler>(
         std::nullopt,

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,6 +54,7 @@ if get_option('build_tests')
         'cask/scheduler/TestBenchScheduler.cpp',
         'cask/scheduler/TestReadyQueue.cpp',
         'cask/scheduler/TestScheduler.cpp',
+        'cask/scheduler/TestSingleThreadScheduler.cpp',
         'cask/task/TestTaskAssignment.cpp',
         'cask/task/TestTaskAsyncBoundary.cpp',
         'cask/task/TestTaskDefer.cpp',


### PR DESCRIPTION
A SingleThreadScheduler constructed with DisableAutoStart spawns a detached run thread that blocks in start_barrier.wait(). If the scheduler is stopped/destructed without ever calling start(), stop() only wakes the ready queue — the run thread remains blocked on the barrier forever, leaking the thread and the SchedulerControlData it holds.

The solution is for stop to properly trigger the start barrier and for run to re-check should_run to prevent it from running in the case where stop is who actually triggered the barrier.