### PR TITLE
fix: use predicate in await_work to avoid missed wakeups

### DIFF
--- a/include/cask/scheduler/ReadyQueue.hpp
+++ b/include/cask/scheduler/ReadyQueue.hpp
@@ -86,12 +86,16 @@ private:
     std::condition_variable work_available;
     std::deque<std::function<void()>> ready_queue;
     std::atomic_size_t memoized_queue_size;
+    bool wake_requested;
 };
 
 template<class Rep, class Period>
 void ReadyQueue::await_work(const std::chrono::duration<Rep,Period>& timeout) {
     std::unique_lock<std::mutex> lock(mutex);
-    work_available.wait_for(lock, timeout);
+    work_available.wait_for(lock, timeout, [this] {
+        return !ready_queue.empty() || wake_requested;
+    });
+    wake_requested = false;
 }
 
 } // namespace cask::scheduler

--- a/src/cask/scheduler/ReadyQueue.cpp
+++ b/src/cask/scheduler/ReadyQueue.cpp
@@ -13,6 +13,7 @@ ReadyQueue::ReadyQueue(std::optional<std::size_t> max_queue_size)
     , work_available()
     , ready_queue()
     , memoized_queue_size(0)
+    , wake_requested(false)
 {}
 
 std::size_t ReadyQueue::size() const {
@@ -112,6 +113,7 @@ bool ReadyQueue::steal_from(ReadyQueue& victim) {
 
 void ReadyQueue::wake() {
     std::lock_guard<std::mutex> lock(mutex);
+    wake_requested = true;
     work_available.notify_all();
 }
 


### PR DESCRIPTION
ReadyQueue::await_work called wait_for on its condition variable without a predicate, which left a window for missed wakeups: if a task was pushed (or wake() was called) between the run loop's empty() check and the worker entering the wait, the notification went to nobody and the worker would sleep for up to its full idle timeout (~12 ms) with work already queued. The same window could delay shutdown, since a wake() from stop() could be lost.

This change adds a wake_requested flag guarded by the queue's existing mutex and passes a predicate (!ready_queue.empty() || wake_requested) to wait_for, so a waiter never sleeps when work is pending and explicit wakes are latched rather than lost. The flag is consumed when the wait returns, and as a side benefit the predicate also handles spurious wakeups correctly.