### PR TITLE
fix: wake an idle scheduler on submitBulk global fallback

### DIFF
--- a/src/cask/scheduler/WorkStealingScheduler.cpp
+++ b/src/cask/scheduler/WorkStealingScheduler.cpp
@@ -127,6 +127,20 @@ bool WorkStealingScheduler::submitBulk(const std::vector<std::function<void()>>&
         for(auto& task : tasks) {
             data->synchronized.global_ready_queue.emplace_back(task);
         }
+
+        // Try and wake up an idle scheduler - starting from
+        // a random start point
+        auto dice_roll = static_cast<std::size_t>(std::abs(std::rand()));
+        auto scheduler_index = dice_roll % (data->fixed.schedulers.size());
+        for(std::size_t i = 0; i < data->fixed.schedulers.size(); i++) {
+            auto selected_scheduler = data->fixed.schedulers[(scheduler_index + i) % data->fixed.schedulers.size()];
+
+            if (!selected_scheduler->isIdle()) continue;
+            if (selected_scheduler->get_run_thread_id() == thread_handle) continue;
+
+            selected_scheduler->try_wake();
+            break;
+        }
     }
 
     return true;


### PR DESCRIPTION
This change updates `submitBulk` so that it has the same behavior as `submit` when falling back to pushing to the global ready queue. Previously, if this fallback happened a latency cost was incurred because it could take some time (up to 12ms) for a thread to wake up and pull from the queue.

With this change, we now go hunting for an idle scheduler and wake it up. This behavior actually isn't new - we already did it during `submit` - this change just makes it so that `submitBulk` has consistent behavior in regards to waking an idle scheduler.