### PR TITLE
fix: preserve timer firing order when evaluating expired timers

### DIFF
--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -283,22 +283,27 @@ void SingleThreadScheduler::run(const std::shared_ptr<SchedulerControlData>& con
 std::deque<std::function<void()>> SingleThreadScheduler::evaluate_timers_unsafe(const std::shared_ptr<SchedulerControlData>& control_data) {
     auto iterationStartTime = current_time_ms();
     std::vector<int64_t> expiredTimes;
+    std::vector<std::function<void()>> expired_tasks;
     std::deque<std::function<void()>> overflowed_tasks;
 
-    // Accumulate any expired tasks
+    // Accumulate any expired tasks, oldest first
     for (auto& [timer_time, timers] : control_data->timers) {
         if (timer_time <= iterationStartTime) {
             for(auto& timer : timers) {
-                auto task = [timer] { timer->fire(); };
-
-                if (auto overflow = control_data->ready_queue.push_front(task)) {
-                    overflowed_tasks.push_front(*overflow);
-                }
+                expired_tasks.emplace_back([timer] { timer->fire(); });
             }
 
             expiredTimes.push_back(timer_time);
         } else {
             break;
+        }
+    }
+
+    // Push expired tasks to the front of the ready queue in reverse so
+    // that the oldest timer lands at the front and fires first.
+    for (auto task_iter = expired_tasks.rbegin(); task_iter != expired_tasks.rend(); ++task_iter) {
+        if (auto overflow = control_data->ready_queue.push_front(*task_iter)) {
+            overflowed_tasks.push_front(*overflow);
         }
     }
 

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -4,9 +4,12 @@
 //          https://www.boost.org/LICENSE_1_0.txt)
 
 #include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <thread>
+#include <vector>
 #include "gtest/gtest.h"
 #include "cask/scheduler/SingleThreadScheduler.hpp"
 
@@ -96,6 +99,55 @@ TEST(SingleThreadSchedulerTest, StartAfterStopDoesNotHang) {
 
     sched->stop();
     sched->start();
+    sched.reset();
+}
+
+TEST(SingleThreadSchedulerTest, FiresExpiredTimersInSubmissionOrder) {
+    // When multiple timers expire before the run loop evaluates them
+    // (e.g. while the scheduler was busy or not yet started), they must
+    // fire oldest-first rather than in reverse order.
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::vector<int> fired_order;
+
+    auto record = [&](int id) {
+        std::lock_guard<std::mutex> lock(mutex);
+        fired_order.push_back(id);
+        cv.notify_one();
+    };
+
+    // Submit timers with strictly increasing expiration times so each
+    // lands in its own timer bucket.
+    sched->submitAfter(5,  [&] { record(0); });
+    sched->submitAfter(10, [&] { record(1); });
+    sched->submitAfter(15, [&] { record(2); });
+
+    // Let all three timers expire before the scheduler ever runs, so a
+    // single evaluation pass sees them all at once.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    sched->start();
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        auto fired = cv.wait_for(lock, std::chrono::seconds(5), [&] {
+            return fired_order.size() == 3;
+        });
+
+        ASSERT_TRUE(fired);
+        EXPECT_EQ(fired_order, (std::vector<int>{0, 1, 2}));
+    }
+
+    sched->stop();
     sched.reset();
 }
 

--- a/test/cask/scheduler/TestSingleThreadScheduler.cpp
+++ b/test/cask/scheduler/TestSingleThreadScheduler.cpp
@@ -106,16 +106,6 @@ TEST(SingleThreadSchedulerTest, FiresExpiredTimersInSubmissionOrder) {
     // When multiple timers expire before the run loop evaluates them
     // (e.g. while the scheduler was busy or not yet started), they must
     // fire oldest-first rather than in reverse order.
-    auto sched = std::make_unique<SingleThreadScheduler>(
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        [](){},
-        [](){},
-        [](auto&){},
-        [](auto&){},
-        cask::scheduler::DisableAutoStart);
-
     std::mutex mutex;
     std::condition_variable cv;
     std::vector<int> fired_order;
@@ -125,6 +115,16 @@ TEST(SingleThreadSchedulerTest, FiresExpiredTimersInSubmissionOrder) {
         fired_order.push_back(id);
         cv.notify_one();
     };
+
+    auto sched = std::make_unique<SingleThreadScheduler>(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        [](){},
+        [](){},
+        [](auto&){},
+        [](auto&){},
+        cask::scheduler::DisableAutoStart);
 
     // Submit timers with strictly increasing expiration times so each
     // lands in its own timer bucket.


### PR DESCRIPTION
Expired timers were iterated oldest-first but each task was pushed to the front of the ready queue, causing later timers to fire before earlier ones.

The fix is to collect expired tasks in order and push them front in reverse so the oldest timer fires first.