### PR TITLE
perf: use intrusive refcounting for FiberOp

### DIFF
--- a/bench/BenchFiberOp.cpp
+++ b/bench/BenchFiberOp.cpp
@@ -1,0 +1,116 @@
+//          Copyright Tango Tango, Inc. 2020 - 2021.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+// Benchmarks targeting the cost of creating ref-counted FiberOp handles.
+// Each FiberOp factory pool-allocates the op; the handle wrapping it must
+// not defeat the pool with extra heap allocations (e.g. a shared_ptr
+// control block) since this is one of the hottest allocation paths.
+
+#include <benchmark/benchmark.h>
+#include <vector>
+#include "cask/Erased.hpp"
+#include "cask/fiber/FiberOp.hpp"
+#include "cask/fiber/FiberValue.hpp"
+#include "cask/pool/InternalPool.hpp"
+
+using cask::Erased;
+using cask::fiber::FiberOp;
+using cask::fiber::FiberValue;
+
+// Single value op create + destroy - the most common operation
+// (every Task::pure / map / flatMap result goes through this).
+static void BM_FiberOp_SharedValue(benchmark::State& state) {
+    auto pool = cask::pool::global_pool();
+    for (auto _ : state) {
+        auto op = FiberOp::value(Erased(42));
+        benchmark::DoNotOptimize(op);
+    }
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_SharedValue)->ThreadRange(1, 8);
+
+// Error op create + destroy.
+static void BM_FiberOp_SharedError(benchmark::State& state) {
+    auto pool = cask::pool::global_pool();
+    for (auto _ : state) {
+        auto op = FiberOp::error(Erased(42));
+        benchmark::DoNotOptimize(op);
+    }
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_SharedError);
+
+// Thunk op create + destroy.
+static void BM_FiberOp_SharedThunk(benchmark::State& state) {
+    auto pool = cask::pool::global_pool();
+    for (auto _ : state) {
+        auto op = FiberOp::thunk([]() { return Erased(42); });
+        benchmark::DoNotOptimize(op);
+    }
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_SharedThunk);
+
+// Valueless op (cede) create + destroy - isolates the shared_ptr wrapping
+// cost since there is no payload allocation at all.
+static void BM_FiberOp_SharedCede(benchmark::State& state) {
+    auto pool = cask::pool::global_pool();
+    for (auto _ : state) {
+        auto op = FiberOp::cede();
+        benchmark::DoNotOptimize(op);
+    }
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_SharedCede);
+
+// Build a flatMap chain - each link creates a VALUE op plus a FLATMAP op,
+// mirroring what Task composition does internally.
+static void BM_FiberOp_FlatMapChainBuild(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+    auto pool = cask::pool::global_pool();
+    for (auto _ : state) {
+        auto op = FiberOp::value(Erased(0));
+        for (int i = 0; i < chain_length; ++i) {
+            op = op->flatMap([](FiberValue&& value) {
+                return FiberOp::value(std::move(value).getValue().value_or(Erased(0)));
+            });
+        }
+        benchmark::DoNotOptimize(op);
+    }
+    state.SetItemsProcessed(state.iterations() * (chain_length + 1));
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_FlatMapChainBuild)->Range(1, 256);
+
+// Copying the shared_ptr (refcount churn) - measures control block traffic
+// in the trampoline, which hands these pointers around constantly.
+static void BM_FiberOp_SharedPtrCopy(benchmark::State& state) {
+    auto pool = cask::pool::global_pool();
+    auto op = FiberOp::value(Erased(42));
+    for (auto _ : state) {
+        auto copy = op;
+        benchmark::DoNotOptimize(copy);
+    }
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_SharedPtrCopy);
+
+// Batch create-then-destroy: stresses both alloc and dealloc paths with
+// many ops alive at once, closer to a real fiber's working set.
+static void BM_FiberOp_BatchChurn(benchmark::State& state) {
+    const int batch = static_cast<int>(state.range(0));
+    auto pool = cask::pool::global_pool();
+    std::vector<cask::fiber::FiberOpRef> ops;
+    ops.reserve(batch);
+    for (auto _ : state) {
+        for (int i = 0; i < batch; ++i) {
+            ops.push_back(FiberOp::value(Erased(i)));
+        }
+        ops.clear();
+    }
+    state.SetItemsProcessed(state.iterations() * batch);
+    benchmark::DoNotOptimize(pool);
+}
+BENCHMARK(BM_FiberOp_BatchChurn)->Range(8, 1024);

--- a/bench/BenchFiberOp.cpp
+++ b/bench/BenchFiberOp.cpp
@@ -4,9 +4,10 @@
 //          https://www.boost.org/LICENSE_1_0.txt)
 
 // Benchmarks targeting the cost of creating ref-counted FiberOp handles.
-// Each FiberOp factory pool-allocates the op; the handle wrapping it must
-// not defeat the pool with extra heap allocations (e.g. a shared_ptr
-// control block) since this is one of the hottest allocation paths.
+// Each FiberOp factory pool-allocates the op and returns a FiberOpRef -
+// an intrusive refcounted pointer. The handle must not defeat the pool
+// with extra heap allocations since this is one of the hottest
+// allocation paths in the library.
 
 #include <benchmark/benchmark.h>
 #include <vector>
@@ -21,7 +22,7 @@ using cask::fiber::FiberValue;
 
 // Single value op create + destroy - the most common operation
 // (every Task::pure / map / flatMap result goes through this).
-static void BM_FiberOp_SharedValue(benchmark::State& state) {
+static void BM_FiberOp_CreateValue(benchmark::State& state) {
     auto pool = cask::pool::global_pool();
     for (auto _ : state) {
         auto op = FiberOp::value(Erased(42));
@@ -29,10 +30,10 @@ static void BM_FiberOp_SharedValue(benchmark::State& state) {
     }
     benchmark::DoNotOptimize(pool);
 }
-BENCHMARK(BM_FiberOp_SharedValue)->ThreadRange(1, 8);
+BENCHMARK(BM_FiberOp_CreateValue)->ThreadRange(1, 8);
 
 // Error op create + destroy.
-static void BM_FiberOp_SharedError(benchmark::State& state) {
+static void BM_FiberOp_CreateError(benchmark::State& state) {
     auto pool = cask::pool::global_pool();
     for (auto _ : state) {
         auto op = FiberOp::error(Erased(42));
@@ -40,10 +41,10 @@ static void BM_FiberOp_SharedError(benchmark::State& state) {
     }
     benchmark::DoNotOptimize(pool);
 }
-BENCHMARK(BM_FiberOp_SharedError);
+BENCHMARK(BM_FiberOp_CreateError);
 
 // Thunk op create + destroy.
-static void BM_FiberOp_SharedThunk(benchmark::State& state) {
+static void BM_FiberOp_CreateThunk(benchmark::State& state) {
     auto pool = cask::pool::global_pool();
     for (auto _ : state) {
         auto op = FiberOp::thunk([]() { return Erased(42); });
@@ -51,11 +52,11 @@ static void BM_FiberOp_SharedThunk(benchmark::State& state) {
     }
     benchmark::DoNotOptimize(pool);
 }
-BENCHMARK(BM_FiberOp_SharedThunk);
+BENCHMARK(BM_FiberOp_CreateThunk);
 
-// Valueless op (cede) create + destroy - isolates the shared_ptr wrapping
-// cost since there is no payload allocation at all.
-static void BM_FiberOp_SharedCede(benchmark::State& state) {
+// Valueless op (cede) create + destroy - isolates the handle and op
+// allocation cost since there is no payload allocation at all.
+static void BM_FiberOp_CreateCede(benchmark::State& state) {
     auto pool = cask::pool::global_pool();
     for (auto _ : state) {
         auto op = FiberOp::cede();
@@ -63,7 +64,7 @@ static void BM_FiberOp_SharedCede(benchmark::State& state) {
     }
     benchmark::DoNotOptimize(pool);
 }
-BENCHMARK(BM_FiberOp_SharedCede);
+BENCHMARK(BM_FiberOp_CreateCede);
 
 // Build a flatMap chain - each link creates a VALUE op plus a FLATMAP op,
 // mirroring what Task composition does internally.
@@ -84,9 +85,10 @@ static void BM_FiberOp_FlatMapChainBuild(benchmark::State& state) {
 }
 BENCHMARK(BM_FiberOp_FlatMapChainBuild)->Range(1, 256);
 
-// Copying the shared_ptr (refcount churn) - measures control block traffic
-// in the trampoline, which hands these pointers around constantly.
-static void BM_FiberOp_SharedPtrCopy(benchmark::State& state) {
+// Copying a FiberOpRef (intrusive refcount churn) - measures the atomic
+// increment/decrement cost in the trampoline, which hands these handles
+// around constantly.
+static void BM_FiberOp_RefCopy(benchmark::State& state) {
     auto pool = cask::pool::global_pool();
     auto op = FiberOp::value(Erased(42));
     for (auto _ : state) {
@@ -95,7 +97,7 @@ static void BM_FiberOp_SharedPtrCopy(benchmark::State& state) {
     }
     benchmark::DoNotOptimize(pool);
 }
-BENCHMARK(BM_FiberOp_SharedPtrCopy);
+BENCHMARK(BM_FiberOp_RefCopy);
 
 // Batch create-then-destroy: stresses both alloc and dealloc paths with
 // many ops alive at once, closer to a real fiber's working set.

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -3,6 +3,7 @@ if get_option('build_benchmarks')
 
     bench_sources = [
         'BenchErased.cpp',
+        'BenchFiberOp.cpp',
         'BenchFlatMap.cpp',
         'BenchPool.cpp',
         'main.cpp'

--- a/include/cask/Fiber.hpp
+++ b/include/cask/Fiber.hpp
@@ -56,7 +56,7 @@ public:
      * @param sched The scheduler to run the Fiber on.
      * @return A Fiber representing the ongoing concurrent execution of the op.
      */
-    static FiberRef<T,E> run(const std::shared_ptr<const fiber::FiberOp>& op, const std::shared_ptr<Scheduler>& sched);
+    static FiberRef<T,E> run(const fiber::FiberOpRef& op, const std::shared_ptr<Scheduler>& sched);
 
     /**
      * Run the given FiberOp without a scheduler.
@@ -68,7 +68,7 @@ public:
      * @return The success or error result of the oeprations execution. If the op
      *         could not be executed without a scheduler then no result is provided.
      */
-    static std::optional<Either<T,E>> runSync(const std::shared_ptr<const fiber::FiberOp>& op);
+    static std::optional<Either<T,E>> runSync(const fiber::FiberOpRef& op);
 
     /**
      * Return the ID of the currently running fiber (if any).
@@ -162,14 +162,14 @@ public:
 namespace cask {
 
 template <class T, class E>
-FiberRef<T,E> Fiber<T,E>::run(const std::shared_ptr<const fiber::FiberOp>& op, const std::shared_ptr<Scheduler>& sched) {
+FiberRef<T,E> Fiber<T,E>::run(const fiber::FiberOpRef& op, const std::shared_ptr<Scheduler>& sched) {
     auto fiber = std::make_shared<fiber::FiberImpl<T,E>>(op);
     fiber->resume(sched);
     return fiber;
 }
 
 template <class T, class E>
-std::optional<Either<T,E>> Fiber<T,E>::runSync(const std::shared_ptr<const fiber::FiberOp>& op) {
+std::optional<Either<T,E>> Fiber<T,E>::runSync(const fiber::FiberOpRef& op) {
     auto fiber = std::make_shared<fiber::FiberImpl<T,E>>(op);
     fiber->resumeSync();
 

--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -805,11 +805,11 @@ public:
      * should not be called directly and, instead, users should use provided
      * operators to build these operations automatically.
      */
-    explicit Task(const std::shared_ptr<const fiber::FiberOp>& op) noexcept
+    explicit Task(const fiber::FiberOpRef& op) noexcept
         : op(op)
     {}
 
-    explicit Task(std::shared_ptr<const fiber::FiberOp>&& op) noexcept
+    explicit Task(fiber::FiberOpRef&& op) noexcept
         : op(std::move(op))
     {}
 
@@ -833,7 +833,7 @@ public:
         return *this;
     }
 
-    std::shared_ptr<const fiber::FiberOp> op;
+    fiber::FiberOpRef op;
 };
 
 } // namespace cask

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -35,7 +35,7 @@ constexpr const char * print_state(const FiberState& state) {
 template <class T, class E>
 class FiberImpl final : public Fiber<T,E> {
 public:
-    explicit FiberImpl(const std::shared_ptr<const FiberOp>& op);
+    explicit FiberImpl(const FiberOpRef& op);
     ~FiberImpl();
 
     FiberState getState();
@@ -88,7 +88,7 @@ private:
     );
 
     uint64_t id;
-    std::shared_ptr<const FiberOp> op;
+    FiberOpRef op;
     std::weak_ptr<Scheduler> last_used_scheduler;
     FiberValue value;
     std::stack<FiberOp::FlatMapPredicate> continuationStack;
@@ -104,7 +104,7 @@ private:
 };
 
 template <class T, class E>
-FiberImpl<T,E>::FiberImpl(const std::shared_ptr<const FiberOp>& op)
+FiberImpl<T,E>::FiberImpl(const FiberOpRef& op)
     : id(CurrentFiber::acquireId())
     , op(op)
     , last_used_scheduler()

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -292,13 +292,15 @@ inline FiberOpRef::FiberOpRef(const FiberOpRef& other) noexcept
 }
 
 inline FiberOpRef& FiberOpRef::operator=(const FiberOpRef& other) noexcept {
-    const FiberOp* old = ptr;
-    ptr = other.ptr;
-    if (ptr) {
-        ptr->retain();
-    }
-    if (old) {
-        old->release();
+    if (this != &other) {
+        const FiberOp* old = ptr;
+        ptr = other.ptr;
+        if (ptr) {
+            ptr->retain();
+        }
+        if (old) {
+            old->release();
+        }
     }
     return *this;
 }

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -7,6 +7,8 @@
 #define _CASK_FIBER_OP_H_
 
 #include <functional>
+#include <atomic>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -29,19 +31,58 @@ using DeferredRef = std::shared_ptr<Deferred<T,E>>;
 
 namespace cask::fiber {
 
-template <class T>
-class PoolDeleter {
-public:
-    explicit PoolDeleter(const std::shared_ptr<Pool>& pool)
-        : pool(pool)
-    {}
+class FiberOp;
 
-    void operator()(T* ptr) {
-        pool->deallocate<T>(ptr);
+/**
+ * An intrusive reference-counted pointer to a `FiberOp`. FiberOps are
+ * allocated from the memory pool and carry their own refcount, so no
+ * separate `shared_ptr` control block is ever heap-allocated for them.
+ * This keeps op creation on the pool fast-path - which matters because
+ * op construction is one of the hottest allocation paths in the library.
+ */
+class FiberOpRef {
+public:
+    constexpr FiberOpRef() noexcept : ptr(nullptr) {}
+    constexpr FiberOpRef(std::nullptr_t) noexcept : ptr(nullptr) {} // NOLINT(google-explicit-constructor)
+
+    explicit FiberOpRef(const FiberOp* op) noexcept;
+
+    FiberOpRef(const FiberOpRef& other) noexcept;
+    FiberOpRef(FiberOpRef&& other) noexcept : ptr(other.ptr) {
+        other.ptr = nullptr;
     }
 
+    FiberOpRef& operator=(const FiberOpRef& other) noexcept;
+    FiberOpRef& operator=(FiberOpRef&& other) noexcept;
+    FiberOpRef& operator=(std::nullptr_t) noexcept;
+
+    ~FiberOpRef();
+
+    /**
+     * Take ownership of an op whose refcount is already accounted for
+     * (e.g. freshly constructed with a refcount of 1) without bumping
+     * the count.
+     */
+    static FiberOpRef adopt(const FiberOp* op) noexcept {
+        return FiberOpRef(op, AdoptTag{});
+    }
+
+    const FiberOp* get() const noexcept { return ptr; }
+    const FiberOp& operator*() const noexcept { return *ptr; }
+    const FiberOp* operator->() const noexcept { return ptr; }
+    explicit operator bool() const noexcept { return ptr != nullptr; }
+
+    bool operator==(const FiberOpRef& other) const noexcept { return ptr == other.ptr; }
+    bool operator!=(const FiberOpRef& other) const noexcept { return ptr != other.ptr; }
+    bool operator==(std::nullptr_t) const noexcept { return ptr == nullptr; }
+    bool operator!=(std::nullptr_t) const noexcept { return ptr != nullptr; }
+
 private:
-    std::shared_ptr<Pool> pool;
+    struct AdoptTag {};
+
+    FiberOpRef(const FiberOp* op, AdoptTag) noexcept : ptr(op) {}
+
+    const FiberOp* ptr;
 };
 
 enum FiberOpType : std::uint8_t { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RACE, CANCEL, CEDE };
@@ -69,18 +110,18 @@ enum FiberOpType : std::uint8_t { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RA
  *      and all other operations are canceled.
  *   6. `Cancel` represents the cancelation of evaluation for the fiber.
  */
-class FiberOp final : public std::enable_shared_from_this<FiberOp> {
+class FiberOp final {
 public:
     // ConstantData is now just Erased (48 bytes) instead of Either<Erased,Erased> (112 bytes).
     // The opType field (VALUE vs ERROR) already tells us which case it is.
     using ConstantData = Erased;
     using AsyncData = std::function<DeferredRef<Erased,Erased>(const std::shared_ptr<Scheduler>&)>;
     using ThunkData = std::function<Erased()>;
-    using FlatMapInput = std::shared_ptr<const FiberOp>;
-    using FlatMapPredicate = std::function<std::shared_ptr<const FiberOp>(FiberValue&&)>;
+    using FlatMapInput = FiberOpRef;
+    using FlatMapPredicate = std::function<FiberOpRef(FiberValue&&)>;
     using FlatMapData = std::pair<FlatMapInput,FlatMapPredicate>;
     using DelayData = int64_t;
-    using RaceData = std::vector<std::shared_ptr<const FiberOp>>;
+    using RaceData = std::vector<FiberOpRef>;
 
     /**
      * The type of operation represented. Used for optimization of internal
@@ -89,19 +130,17 @@ public:
     FiberOpType opType;
 
     template <typename Arg>
-    static std::shared_ptr<const FiberOp> value(Arg&& value) noexcept  {
+    static FiberOpRef value(Arg&& value) noexcept  {
         auto pool = cask::pool::global_pool();
         auto constant = pool->allocate<ConstantData>(std::forward<Arg>(value));
-        auto op = pool->allocate<FiberOp>(constant, pool, VALUE);
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(constant, pool, VALUE));
     }
 
     template <typename Arg>
-    static std::shared_ptr<const FiberOp> error(Arg&& error) noexcept {
+    static FiberOpRef error(Arg&& error) noexcept {
         auto pool = cask::pool::global_pool();
         auto constant = pool->allocate<ConstantData>(std::forward<Arg>(error));
-        auto op = pool->allocate<FiberOp>(constant, pool, ERROR);
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(constant, pool, ERROR));
     }
 
     template <typename Predicate, typename = std::enable_if_t<
@@ -110,11 +149,10 @@ public:
             std::function<DeferredRef<Erased,Erased>(const std::shared_ptr<Scheduler>&)>
         >::value
     >>
-    static std::shared_ptr<const FiberOp> async(Predicate&& predicate) noexcept {
+    static FiberOpRef async(Predicate&& predicate) noexcept {
         auto pool = cask::pool::global_pool();
         auto async_data = pool->allocate<AsyncData>(std::forward<Predicate>(predicate));
-        auto op = pool->allocate<FiberOp>(async_data, pool); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(async_data, pool));
     }
 
     template <typename Predicate, typename = std::enable_if_t<
@@ -123,43 +161,38 @@ public:
             std::function<Erased()>
         >::value
     >>
-    static std::shared_ptr<const FiberOp> thunk(Predicate&& thunk) noexcept {
+    static FiberOpRef thunk(Predicate&& thunk) noexcept {
         auto pool = cask::pool::global_pool();
         auto thunk_data = pool->allocate<ThunkData>(std::forward<Predicate>(thunk));
-        auto op = pool->allocate<FiberOp>(thunk_data, pool); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(thunk_data, pool));
     }
 
-    static std::shared_ptr<const FiberOp> delay(int64_t delay_ms) noexcept {
+    static FiberOpRef delay(int64_t delay_ms) noexcept {
         auto pool = cask::pool::global_pool();
         auto delay_data = pool->allocate<DelayData>(delay_ms);
-        auto op = pool->allocate<FiberOp>(delay_data, pool); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(delay_data, pool));
     }
 
-    template <typename Arg = std::vector<std::shared_ptr<const FiberOp>>, typename = std::enable_if_t<
+    template <typename Arg = std::vector<FiberOpRef>, typename = std::enable_if_t<
         std::is_convertible<
             std::remove_reference_t<Arg>,
-            std::vector<std::shared_ptr<const FiberOp>>
+            std::vector<FiberOpRef>
         >::value
     >>
-    static std::shared_ptr<const FiberOp> race(Arg&& race) noexcept {
+    static FiberOpRef race(Arg&& race) noexcept {
         auto pool = cask::pool::global_pool();
         auto race_data = pool->allocate<RaceData>(std::forward<Arg>(race));
-        auto op = pool->allocate<FiberOp>(race_data, pool); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(race_data, pool));
     }
 
-    static std::shared_ptr<const FiberOp> cancel() noexcept {
+    static FiberOpRef cancel() noexcept {
         auto pool = cask::pool::global_pool();
-        auto op = pool->allocate<FiberOp>(CANCEL); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(CANCEL, pool));
     }
 
-    static std::shared_ptr<const FiberOp> cede() noexcept  {
+    static FiberOpRef cede() noexcept  {
         auto pool = cask::pool::global_pool();
-        auto op = pool->allocate<FiberOp>(CEDE); 
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(CEDE, pool));
     }
 
     /**
@@ -176,14 +209,40 @@ public:
             FlatMapPredicate
         >::value
     >>
-    std::shared_ptr<const FiberOp> flatMap(Predicate&& predicate) const noexcept  {
+    FiberOpRef flatMap(Predicate&& predicate) const noexcept  {
         // Always create a new FLATMAP node wrapping this operation.
         // The continuation stack in FiberImpl handles chaining during evaluation,
         // so we don't need to create nested closures here.
         auto pool = cask::pool::global_pool();
-        auto data = pool->allocate<FlatMapData>(this->shared_from_this(), std::forward<Predicate>(predicate));
-        auto op = pool->allocate<FiberOp>(data, pool);
-        return std::shared_ptr<FiberOp>(op, PoolDeleter<FiberOp>(pool));
+        auto data = pool->allocate<FlatMapData>(FiberOpRef(this), std::forward<Predicate>(predicate));
+        return FiberOpRef::adopt(pool->allocate<FiberOp>(data, pool));
+    }
+
+    /**
+     * Increment this op's intrusive reference count. Normally called only
+     * by `FiberOpRef`.
+     */
+    void retain() const noexcept {
+        refcount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    /**
+     * Decrement this op's intrusive reference count - destroying the op and
+     * returning its memory to the pool when the count reaches zero. Normally
+     * called only by `FiberOpRef`.
+     */
+    void release() const noexcept {
+        if (refcount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            auto* self = const_cast<FiberOp*>(this); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+
+            // Move the pool reference out of the object so it (and the pool
+            // itself) reliably outlives the deallocation of this op. The
+            // destructor sees a null pool and skips payload cleanup, so the
+            // payload is released explicitly first.
+            std::shared_ptr<Pool> local_pool = std::move(self->pool);
+            self->deallocatePayload(*local_pool);
+            local_pool->deallocate<FiberOp>(self);
+        }
     }
 
     union {
@@ -205,13 +264,71 @@ public:
     explicit FiberOp(FlatMapData* flatMap, const std::shared_ptr<Pool>& pool) noexcept;
     explicit FiberOp(DelayData* delay, const std::shared_ptr<Pool>& pool) noexcept;
     explicit FiberOp(RaceData* race, const std::shared_ptr<Pool>& pool) noexcept;
-    explicit FiberOp(FiberOpType valueless_op) noexcept;
+    explicit FiberOp(FiberOpType valueless_op, const std::shared_ptr<Pool>& pool) noexcept;
 
     ~FiberOp();
     
 private:
+    void deallocatePayload(Pool& pool) noexcept;
+
+    mutable std::atomic<std::uint32_t> refcount;
     std::shared_ptr<Pool> pool;
 };
+
+inline FiberOpRef::FiberOpRef(const FiberOp* op) noexcept
+    : ptr(op)
+{
+    if (ptr) {
+        ptr->retain();
+    }
+}
+
+inline FiberOpRef::FiberOpRef(const FiberOpRef& other) noexcept
+    : ptr(other.ptr)
+{
+    if (ptr) {
+        ptr->retain();
+    }
+}
+
+inline FiberOpRef& FiberOpRef::operator=(const FiberOpRef& other) noexcept {
+    const FiberOp* old = ptr;
+    ptr = other.ptr;
+    if (ptr) {
+        ptr->retain();
+    }
+    if (old) {
+        old->release();
+    }
+    return *this;
+}
+
+inline FiberOpRef& FiberOpRef::operator=(FiberOpRef&& other) noexcept {
+    if (this != &other) {
+        const FiberOp* old = ptr;
+        ptr = other.ptr;
+        other.ptr = nullptr;
+        if (old) {
+            old->release();
+        }
+    }
+    return *this;
+}
+
+inline FiberOpRef& FiberOpRef::operator=(std::nullptr_t) noexcept {
+    const FiberOp* old = ptr;
+    ptr = nullptr;
+    if (old) {
+        old->release();
+    }
+    return *this;
+}
+
+inline FiberOpRef::~FiberOpRef() {
+    if (ptr) {
+        ptr->release();
+    }
+}
 
 } // namespace cask::fiber
 

--- a/src/cask/fiber/FiberOp.cpp
+++ b/src/cask/fiber/FiberOp.cpp
@@ -15,6 +15,7 @@ namespace cask::fiber {
 
 FiberOp::FiberOp(AsyncData* async, const std::shared_ptr<Pool>& pool) noexcept
     : opType(ASYNC)
+    , refcount(1)
     , pool(pool)
 {
     data.asyncData = async;
@@ -22,6 +23,7 @@ FiberOp::FiberOp(AsyncData* async, const std::shared_ptr<Pool>& pool) noexcept
 
 FiberOp::FiberOp(ConstantData* constant, const std::shared_ptr<Pool>& pool, FiberOpType type) noexcept
     : opType(type)
+    , refcount(1)
     , pool(pool)
 {
     data.constantData = constant;
@@ -29,6 +31,7 @@ FiberOp::FiberOp(ConstantData* constant, const std::shared_ptr<Pool>& pool, Fibe
 
 FiberOp::FiberOp(ThunkData* thunk, const std::shared_ptr<Pool>& pool) noexcept
     : opType(THUNK)
+    , refcount(1)
     , pool(pool)
 {
     data.thunkData = thunk;
@@ -36,6 +39,7 @@ FiberOp::FiberOp(ThunkData* thunk, const std::shared_ptr<Pool>& pool) noexcept
 
 FiberOp::FiberOp(FlatMapData* flatMap, const std::shared_ptr<Pool>& pool) noexcept
     : opType(FLATMAP)
+    , refcount(1)
     , pool(pool)
 {
     data.flatMapData = flatMap;
@@ -43,6 +47,7 @@ FiberOp::FiberOp(FlatMapData* flatMap, const std::shared_ptr<Pool>& pool) noexce
 
 FiberOp::FiberOp(DelayData* delay, const std::shared_ptr<Pool>& pool) noexcept
     : opType(DELAY)
+    , refcount(1)
     , pool(pool)
 {
     data.delayData = delay;
@@ -50,41 +55,52 @@ FiberOp::FiberOp(DelayData* delay, const std::shared_ptr<Pool>& pool) noexcept
 
 FiberOp::FiberOp(RaceData* race, const std::shared_ptr<Pool>& pool) noexcept
     : opType(RACE)
+    , refcount(1)
     , pool(pool)
 {
     data.raceData = race;
 }
 
-FiberOp::FiberOp(FiberOpType valueless_op) noexcept
+FiberOp::FiberOp(FiberOpType valueless_op, const std::shared_ptr<Pool>& pool) noexcept
     : opType(valueless_op)
-    , pool()
+    , refcount(1)
+    , pool(pool)
 {}
 
-
-FiberOp::~FiberOp() {
+void FiberOp::deallocatePayload(Pool& pool) noexcept {
     switch(opType) {
         case VALUE:
         case ERROR:
-            pool->deallocate<ConstantData>(data.constantData);
+            pool.deallocate<ConstantData>(data.constantData);
         break;
         case THUNK:
-            pool->deallocate<ThunkData>(data.thunkData);
+            pool.deallocate<ThunkData>(data.thunkData);
         break;
         case ASYNC:
-            pool->deallocate<AsyncData>(data.asyncData);
+            pool.deallocate<AsyncData>(data.asyncData);
         break;
         case FLATMAP:
-            pool->deallocate<FlatMapData>(data.flatMapData);
+            pool.deallocate<FlatMapData>(data.flatMapData);
         break;
         case DELAY:
-            pool->deallocate<DelayData>(data.delayData);
+            pool.deallocate<DelayData>(data.delayData);
         break;
         case RACE:
-            pool->deallocate<RaceData>(data.raceData);
+            pool.deallocate<RaceData>(data.raceData);
         break;
         case CANCEL:
         case CEDE:
         break;
+    }
+}
+
+FiberOp::~FiberOp() {
+    // When destroyed via release() the pool member has already been moved
+    // out (and the payload freed) - so only clean up the payload here when
+    // the op is destroyed directly (e.g. by Pool::deallocate on an op which
+    // was never wrapped in a FiberOpRef).
+    if (pool) {
+        deallocatePayload(*pool);
     }
 }
 

--- a/test/cask/fiber/TestFiberOp.cpp
+++ b/test/cask/fiber/TestFiberOp.cpp
@@ -155,7 +155,7 @@ TEST(FiberOpRef, MoveTransfersOwnership) {
     const auto* raw = op.get();
 
     auto moved = std::move(op);
-    EXPECT_EQ(op.get(), nullptr); // NOLINT(bugprone-use-after-move): intentionally checking moved-from state
+    EXPECT_EQ(op.get(), nullptr); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move): intentionally checking moved-from state
     EXPECT_EQ(moved.get(), raw);
     EXPECT_GT(token.use_count(), 1);
 
@@ -192,7 +192,7 @@ TEST(FiberOpRef, MoveAssignReleasesPreviousTarget) {
 
     EXPECT_EQ(first_token.use_count(), 1);
     EXPECT_GT(second_token.use_count(), 1);
-    EXPECT_EQ(second.get(), nullptr); // NOLINT(bugprone-use-after-move): intentionally checking moved-from state
+    EXPECT_EQ(second.get(), nullptr); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move): intentionally checking moved-from state
 
     first = nullptr;
     EXPECT_EQ(second_token.use_count(), 1);
@@ -218,7 +218,7 @@ TEST(FiberOpRef, FlatMapRetainsInputOp) {
     auto token = std::make_shared<int>(42);
 
     auto input = opHoldingToken(token);
-    auto composed = input->flatMap([](auto&& value) {
+    auto composed = input->flatMap([](cask::fiber::FiberValue&& value) {
         return FiberOp::value(std::move(value).getValue().value_or(Erased(0)));
     });
 

--- a/test/cask/fiber/TestFiberOp.cpp
+++ b/test/cask/fiber/TestFiberOp.cpp
@@ -108,3 +108,143 @@ TEST(FiberOp, FlatMap) {
     ASSERT_EQ(input->opType, cask::fiber::VALUE);
     ASSERT_TRUE(predicate);
 }
+
+// --- FiberOpRef intrusive reference counting lifetime tests ---
+
+namespace {
+
+cask::fiber::FiberOpRef opHoldingToken(const std::shared_ptr<int>& token) {
+    return FiberOp::thunk([token] {
+        return Erased(*token);
+    });
+}
+
+} // namespace
+
+TEST(FiberOpRef, DestroysPayloadWhenLastRefDropped) {
+    auto token = std::make_shared<int>(42);
+
+    {
+        auto op = opHoldingToken(token);
+        EXPECT_GT(token.use_count(), 1);
+    }
+
+    EXPECT_EQ(token.use_count(), 1);
+}
+
+TEST(FiberOpRef, CopyExtendsLifetime) {
+    auto token = std::make_shared<int>(42);
+
+    auto op = opHoldingToken(token);
+    auto copy = op;
+
+    EXPECT_EQ(op.get(), copy.get());
+
+    op = nullptr;
+    EXPECT_EQ(op.get(), nullptr);
+    EXPECT_GT(token.use_count(), 1);
+
+    copy = nullptr;
+    EXPECT_EQ(token.use_count(), 1);
+}
+
+TEST(FiberOpRef, MoveTransfersOwnership) {
+    auto token = std::make_shared<int>(42);
+
+    auto op = opHoldingToken(token);
+    const auto* raw = op.get();
+
+    auto moved = std::move(op);
+    EXPECT_EQ(op.get(), nullptr); // NOLINT(bugprone-use-after-move): intentionally checking moved-from state
+    EXPECT_EQ(moved.get(), raw);
+    EXPECT_GT(token.use_count(), 1);
+
+    moved = nullptr;
+    EXPECT_EQ(token.use_count(), 1);
+}
+
+TEST(FiberOpRef, CopyAssignReleasesPreviousTarget) {
+    auto first_token = std::make_shared<int>(1);
+    auto second_token = std::make_shared<int>(2);
+
+    auto first = opHoldingToken(first_token);
+    auto second = opHoldingToken(second_token);
+
+    first = second;
+
+    EXPECT_EQ(first_token.use_count(), 1);
+    EXPECT_GT(second_token.use_count(), 1);
+    EXPECT_EQ(first.get(), second.get());
+
+    first = nullptr;
+    second = nullptr;
+    EXPECT_EQ(second_token.use_count(), 1);
+}
+
+TEST(FiberOpRef, MoveAssignReleasesPreviousTarget) {
+    auto first_token = std::make_shared<int>(1);
+    auto second_token = std::make_shared<int>(2);
+
+    auto first = opHoldingToken(first_token);
+    auto second = opHoldingToken(second_token);
+
+    first = std::move(second);
+
+    EXPECT_EQ(first_token.use_count(), 1);
+    EXPECT_GT(second_token.use_count(), 1);
+    EXPECT_EQ(second.get(), nullptr); // NOLINT(bugprone-use-after-move): intentionally checking moved-from state
+
+    first = nullptr;
+    EXPECT_EQ(second_token.use_count(), 1);
+}
+
+TEST(FiberOpRef, SelfCopyAssignIsSafe) {
+    auto token = std::make_shared<int>(42);
+
+    auto op = opHoldingToken(token);
+    const auto* raw = op.get();
+
+    auto& alias = op;
+    op = alias;
+
+    EXPECT_EQ(op.get(), raw);
+    EXPECT_GT(token.use_count(), 1);
+
+    op = nullptr;
+    EXPECT_EQ(token.use_count(), 1);
+}
+
+TEST(FiberOpRef, FlatMapRetainsInputOp) {
+    auto token = std::make_shared<int>(42);
+
+    auto input = opHoldingToken(token);
+    auto composed = input->flatMap([](auto&& value) {
+        return FiberOp::value(std::move(value).getValue().value_or(Erased(0)));
+    });
+
+    // Dropping the original handle must not destroy the input op - the
+    // FLATMAP node holds its own reference to it.
+    input = nullptr;
+    EXPECT_GT(token.use_count(), 1);
+    EXPECT_EQ(composed->data.flatMapData->first->opType, cask::fiber::THUNK);
+
+    composed = nullptr;
+    EXPECT_EQ(token.use_count(), 1);
+}
+
+TEST(FiberOpRef, RaceRetainsRacers) {
+    auto first_token = std::make_shared<int>(1);
+    auto second_token = std::make_shared<int>(2);
+
+    auto race = FiberOp::race({
+        opHoldingToken(first_token),
+        opHoldingToken(second_token)
+    });
+
+    EXPECT_GT(first_token.use_count(), 1);
+    EXPECT_GT(second_token.use_count(), 1);
+
+    race = nullptr;
+    EXPECT_EQ(first_token.use_count(), 1);
+    EXPECT_EQ(second_token.use_count(), 1);
+}

--- a/test/cask/fiber/TestFiberOp.cpp
+++ b/test/cask/fiber/TestFiberOp.cpp
@@ -68,7 +68,7 @@ TEST(FiberOp, Delay) {
 }
 
 TEST(FiberOp, RaceCopy) {
-    std::vector<std::shared_ptr<const FiberOp>> ops = {FiberOp::value(123), FiberOp::value(456)};
+    std::vector<cask::fiber::FiberOpRef> ops = {FiberOp::value(123), FiberOp::value(456)};
     auto op = FiberOp::race(ops);
 
     ASSERT_EQ(op->opType, cask::fiber::RACE);


### PR DESCRIPTION
Right now FiberOp is passed around as a `std::shared_ptr` whose content is allocated on the memory pool but the shared pointer control block is allocated on the normal heap. This causes a double allocation for the refcount as well as extra cache pressure since the cache lines for the the data and control block have to be loaded for things to work.

This is a known optimization issue and the C++ STL _does_ provide some ways to work around them. In testing, though, these actually resulted in worse performance due to extra overhead incurred in the inevitable implementation.

This change implements the fastest and most straightforward optimization found - which is to move to an intrusive refcount. We could have pulled this from boost, but chose a bespoke implementation just to limit dependencies as much as possible.

The result is a huge performance uplift across all benchmarks on my local machine - between roughly 20% and 45% depending on the benchmark executed. I suspect the benefits will be even more pronounced on embedded platforms that are cache and memory bandwidth starved.

There is a very minor change to the api as now things pass around `FiberOpRef` rather than a `std::shared_ptr<const FiberOp>` but the change is an internal implementation detail. Consumers are never expected to mess with a `FiberOp` at all. As a result, I'm not major revving the library unless an actual consumer-facing API regression is detected in review.