### PR TITLE
fix: resolve tsan identified correctness issues

### DIFF
--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -87,6 +87,18 @@ private:
         const std::shared_ptr<Scheduler>& sched
     );
 
+    // Concurrent lock() and assignment on the same weak_ptr is a data race, so
+    // all access to last_used_scheduler is guarded by scheduler_mutex.
+    void setLastScheduler(const std::shared_ptr<Scheduler>& sched) {
+        std::lock_guard<std::mutex> guard(scheduler_mutex);
+        last_used_scheduler = sched;
+    }
+
+    std::shared_ptr<Scheduler> getLastScheduler() {
+        std::lock_guard<std::mutex> guard(scheduler_mutex);
+        return last_used_scheduler.lock();
+    }
+
     uint64_t id;
     FiberOpRef op;
     std::weak_ptr<Scheduler> last_used_scheduler;
@@ -97,6 +109,7 @@ private:
     CancelableRef delayedBy;
     std::mutex callback_mutex;
     std::mutex racing_fibers_mutex;
+    std::mutex scheduler_mutex;
     std::vector<std::function<void(Fiber<T,E>*)>> callbacks;
     std::atomic_bool attempting_cancel;
     std::optional<FiberValue> race_result;
@@ -115,6 +128,7 @@ FiberImpl<T,E>::FiberImpl(const FiberOpRef& op)
     , delayedBy()
     , callback_mutex()
     , racing_fibers_mutex()
+    , scheduler_mutex()
     , callbacks()
     , attempting_cancel(false)
     , racing_fibers()
@@ -147,11 +161,11 @@ bool FiberImpl<T,E>::resumeUnsafe(const std::shared_ptr<Scheduler>& sched, std::
 
     FiberState current_state = state.load(std::memory_order_relaxed);
 
-    if(state != READY || (state == READY && !state.compare_exchange_strong(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed))) {
+    if(current_state != READY || !state.compare_exchange_strong(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
         return false;
     }
 
-    last_used_scheduler = std::weak_ptr<Scheduler>(sched);
+    setLastScheduler(sched);
 
     while(forced_cede_disabled || cede_iterations-- > 0) {
         if(this->template evaluateOp<Async>(sched)) {
@@ -416,11 +430,23 @@ bool FiberImpl<T,E>::racerFinished(const std::shared_ptr<Fiber<Erased,Erased>>& 
     // If this was the last racer, then its time to finish up
     // by setting up the value and resuming the monitor fiber
     if (last_racer) {
-        if (!value.isCanceled()) {
-            value = race_result.value();
+        // Take ownership of the fiber by transitioning RACING -> RUNNING.
+        // This is done while holding racing_fibers_mutex so that it
+        // serializes with a concurrent cancel(), which reads the state and
+        // mutates `value` under the same mutex while the fiber is RACING.
+        {
+            std::lock_guard<std::mutex> guard(racing_fibers_mutex);
+
+            FiberState expected = RACING;
+            if (!state.compare_exchange_strong(expected, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
+                return false;
+            }
+
+            if (!value.isCanceled()) {
+                value = race_result.value();
+            }
         }
 
-        state.store(RUNNING, std::memory_order_release);
         if(!finishIteration()) {
             state.store(READY, std::memory_order_release);
         }
@@ -433,7 +459,7 @@ bool FiberImpl<T,E>::racerFinished(const std::shared_ptr<Fiber<Erased,Erased>>& 
 
 template <class T, class E>
 void FiberImpl<T,E>::reschedule(const std::shared_ptr<Scheduler>& sched) {
-    last_used_scheduler = sched;
+    setLastScheduler(sched);
     sched->submit([self_weak = this->weak_from_this(), sched_weak = std::weak_ptr<Scheduler>(sched)] {
         if(auto self = self_weak.lock()) {
             if(auto sched = sched_weak.lock()) {
@@ -579,7 +605,7 @@ bool FiberImpl<T,E>::evaluateOp(const std::shared_ptr<Scheduler>& sched) {
 
                 for(auto& racer: *data) {
                     auto fiber = std::make_shared<FiberImpl<Erased,Erased>>(racer);
-                    fiber->last_used_scheduler = sched;
+                    fiber->setLastScheduler(sched);
                     fiber->onFiberShutdown([
                         self_weak = this->weak_from_this(),
                         fiber_weak = std::weak_ptr<FiberImpl<Erased,Erased>>(fiber),
@@ -652,13 +678,40 @@ void FiberImpl<T,E>::cancel() {
 
     while(true) {
         current_state = state.load(std::memory_order_relaxed);
-        if(state == COMPLETED || state == CANCELED) {
+        if(current_state == COMPLETED || current_state == CANCELED) {
             return;
-        } else if (state != RUNNING) {
+        } else if (current_state == RACING) {
+            // While racing, ownership of `value` is arbitrated by
+            // racing_fibers_mutex rather than the state machine so that we
+            // never transiently flip the state and starve racerFinished.
+            std::vector<FiberRef<Erased,Erased>> local_racers;
+
+            {
+                std::lock_guard<std::mutex> guard(racing_fibers_mutex);
+
+                if (state.load(std::memory_order_relaxed) != RACING) {
+                    // The last racer finished and took ownership while we
+                    // were acquiring the lock - re-evaluate the state.
+                    continue;
+                }
+
+                value.setCanceled();
+
+                for(const auto& entry: racing_fibers) {
+                    local_racers.emplace_back(std::get<1>(entry));
+                }
+            }
+
+            if (!local_racers.empty()) {
+                local_racers[0]->cancel();
+            }
+
+            return;
+        } else if (current_state != RUNNING) {
             if(state.compare_exchange_weak(current_state, RUNNING, std::memory_order_acquire, std::memory_order_relaxed)) {
                 break;
             }
-        } else if (auto sched = last_used_scheduler.lock()) {
+        } else if (auto sched = getLastScheduler()) {
             sched->submit([self_weak = this->weak_from_this()] {
                 if(auto self = self_weak.lock()) {
                     self->cancel();
@@ -681,30 +734,12 @@ void FiberImpl<T,E>::cancel() {
         state.store(DELAYED, std::memory_order_release);
         localDelayedBy->cancel();
         return;
-    } else if(current_state == RACING) {
-        state.store(RACING, std::memory_order_release);
-
-        std::vector<FiberRef<Erased,Erased>> local_racers;
-
-        {
-            std::lock_guard<std::mutex> guard(racing_fibers_mutex);
-            for(const auto& entry: racing_fibers) {
-                const auto& fiber = std::get<1>(entry);
-                local_racers.emplace_back(fiber);
-            }
-        }
-
-        if (!local_racers.empty()) {
-            local_racers[0]->cancel();
-        }
-        
-        return;
     }
     
     if(!finishIteration()) {
         state.store(READY, std::memory_order_release);
 
-        if(auto sched = last_used_scheduler.lock()) {
+        if(auto sched = getLastScheduler()) {
             reschedule(sched);
         } else {
             resumeSync();

--- a/include/cask/pool/BlockPool.hpp
+++ b/include/cask/pool/BlockPool.hpp
@@ -38,7 +38,7 @@ public:
     void deallocate(T* ptr);
 
 private:
-    static constexpr std::size_t TotalBlockSize = BlockSize + sizeof(void*);
+    static constexpr std::size_t TotalBlockSize = BlockSize + sizeof(std::atomic<void*>);
     static constexpr std::size_t PadSize = (Alignment - (TotalBlockSize % Alignment)) % Alignment;
 
     struct Chunk;
@@ -48,7 +48,7 @@ private:
         BlockWithPad() : next(nullptr) {}
 
         uint8_t memory[BlockSize];
-        BlockWithPad* next;
+        std::atomic<BlockWithPad*> next;
         std::uint8_t padding[PadSize == 0 ? 1 : PadSize];
     };
 
@@ -57,7 +57,7 @@ private:
         BlockWithoutPad() : next(nullptr) {}
 
         uint8_t memory[BlockSize];
-        BlockWithoutPad* next;
+        std::atomic<BlockWithoutPad*> next;
     };
 
     // Choose the block type. Most of the time at least some padding is required, but
@@ -130,15 +130,17 @@ T* BlockPool<BlockSize,NumBlocksInChunk,Alignment>::allocate(Args&&... args) {
     static_assert(sizeof(T) <= BlockSize);
 
     while(true) {
-        Head<Block> old_head = free_blocks.load(std::memory_order_relaxed);
+        // Acquire so that dereferencing old_head.ptr->next below synchronizes with
+        // the release-CAS that published the block (or its freshly constructed chunk).
+        Head<Block> old_head = free_blocks.load(std::memory_order_acquire);
 
         if(old_head.ptr) {
             Head<Block> new_head;
-            new_head.ptr = old_head.ptr->next;
+            new_head.ptr = old_head.ptr->next.load(std::memory_order_relaxed);
             new_head.counter = old_head.counter + 1;
-            if(free_blocks.compare_exchange_weak(old_head, new_head, std::memory_order_acquire, std::memory_order_relaxed)) {
+            if(free_blocks.compare_exchange_weak(old_head, new_head, std::memory_order_acquire, std::memory_order_acquire)) {
                 UNPOISON_BLOCK(old_head.ptr);
-                old_head.ptr->next = nullptr;
+                old_head.ptr->next.store(nullptr, std::memory_order_relaxed);
                 return new (old_head.ptr->memory) T(std::forward<Args>(args)...);
             }
 
@@ -163,7 +165,7 @@ void BlockPool<BlockSize,NumBlocksInChunk,Alignment>::deallocate(T* ptr) {
 
     do {
         new_head.ptr = block;
-        new_head.ptr->next = old_head.ptr;
+        new_head.ptr->next.store(old_head.ptr, std::memory_order_relaxed);
         new_head.counter = old_head.counter + 1;
     } while(!free_blocks.compare_exchange_weak(old_head,new_head, std::memory_order_release, std::memory_order_relaxed));
 }
@@ -189,7 +191,7 @@ void BlockPool<BlockSize,NumBlocksInChunk,Alignment>::allocate_chunk() {
         // the free list
         for (std::size_t i = 0; i < NumBlocksInChunk; i++) {
             Block* block = &(chunk->blocks[i]);
-            block->next = (i < NumBlocksInChunk - 1) ? &(chunk->blocks[i + 1]) : nullptr;
+            block->next.store((i < NumBlocksInChunk - 1) ? &(chunk->blocks[i + 1]) : nullptr, std::memory_order_relaxed);
             POISON_BLOCK(block);
         }
 
@@ -197,7 +199,7 @@ void BlockPool<BlockSize,NumBlocksInChunk,Alignment>::allocate_chunk() {
         Head<Block> old_head = free_blocks.load(std::memory_order_relaxed);
         Head<Block> new_head;
         do {
-            chunk->blocks[NumBlocksInChunk - 1].next = old_head.ptr;
+            chunk->blocks[NumBlocksInChunk - 1].next.store(old_head.ptr, std::memory_order_relaxed);
             new_head.ptr = &(chunk->blocks[0]);
             new_head.counter = old_head.counter + 1;
         } while (!free_blocks.compare_exchange_weak(old_head, new_head,

--- a/test/SchedulerTestBench.hpp
+++ b/test/SchedulerTestBench.hpp
@@ -1,11 +1,36 @@
 #pragma once
 
+#include <condition_variable>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include "cask/Scheduler.hpp"
 #include "cask/scheduler/SingleThreadScheduler.hpp"
 #include "cask/scheduler/WorkStealingScheduler.hpp"
+
+// A simple one-shot cross-thread signal built on a mutex and condition
+// variable. Safe to notify and wait concurrently from different threads.
+class TestSignal {
+public:
+    void notify() {
+        // Notify while holding the lock so the broadcast cannot race with a
+        // waiter waking up and destroying this signal.
+        std::lock_guard<std::mutex> lock(mutex);
+        fired = true;
+        cond.notify_all();
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lock(mutex);
+        cond.wait(lock, [this] { return fired; });
+    }
+
+private:
+    std::mutex mutex;
+    std::condition_variable cond;
+    bool fired = false;
+};
 
 struct SchedulerTestBenchEntry {
     std::function<std::shared_ptr<cask::Scheduler>()> factory;

--- a/test/cask/TestPromiseDeferred.cpp
+++ b/test/cask/TestPromiseDeferred.cpp
@@ -10,6 +10,7 @@
 #include "cask/scheduler/BenchScheduler.hpp"
 #include "SchedulerTestBench.hpp"
 #include <chrono>
+#include <future>
 #include <thread>
 
 using cask::Promise;
@@ -149,77 +150,73 @@ TEST_P(DeferredTest, Promise) {
 }
 
 TEST_P(DeferredTest, PromiseOnCompleteSuccess) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
 
     Either<int,std::string> result = Either<int,std::string>::left(0);
-    deferred->onComplete([&result, &mutex](auto value) {
+    deferred->onComplete([&result, &signal](auto value) {
         result = value;
-        mutex.unlock();
+        signal.set_value();
     });
 
     promise->success(123);
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(result.get_left(), 123);
 }
 
 TEST_P(DeferredTest, PromiseOnCompleteError) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
 
     Either<int,std::string> result = Either<int,std::string>::left(0);
-    deferred->onComplete([&result, &mutex](auto value) {
+    deferred->onComplete([&result, &signal](auto value) {
         result = value;
-        mutex.unlock();
+        signal.set_value();
     });
 
     promise->error("broke");
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(result.get_right(), "broke");
 }
 
 TEST_P(DeferredTest, PromiseOnSuccess) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
 
     int result = 0;
-    deferred->onSuccess([&result, &mutex](auto value) {
+    deferred->onSuccess([&result, &signal](auto value) {
         result = value;
-        mutex.unlock();
+        signal.set_value();
     });
 
     promise->success(123);
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(result, 123);
 }
 
 TEST_P(DeferredTest, PromiseOnError) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
 
     std::string result = "not called";
-    deferred->onError([&result, &mutex](auto value) {
+    deferred->onError([&result, &signal](auto value) {
         result = value;
-        mutex.unlock();
+        signal.set_value();
     });
 
     promise->error("broke");
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(result, "broke");
 }
@@ -248,20 +245,19 @@ TEST_P(DeferredTest, PromiseAwaitSyncError) {
 }
 
 TEST_P(DeferredTest, PromiseAwaitAsync) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> started;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
     int value;
 
-    std::thread backgroundAwait([&value, &mutex, &deferred]() {
-        mutex.unlock();
+    std::thread backgroundAwait([&value, &started, &deferred]() {
+        started.set_value();
         value = deferred->await();
     });
 
     // Wait for background thread to get started
-    mutex.lock();
+    started.get_future().wait();
 
     // Complete the promise after a small sleep (to be triple sure that
     // the await is running).

--- a/test/cask/TestPromiseDeferred.cpp
+++ b/test/cask/TestPromiseDeferred.cpp
@@ -10,7 +10,6 @@
 #include "cask/scheduler/BenchScheduler.hpp"
 #include "SchedulerTestBench.hpp"
 #include <chrono>
-#include <future>
 #include <thread>
 
 using cask::Promise;
@@ -150,7 +149,7 @@ TEST_P(DeferredTest, Promise) {
 }
 
 TEST_P(DeferredTest, PromiseOnCompleteSuccess) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
@@ -158,17 +157,17 @@ TEST_P(DeferredTest, PromiseOnCompleteSuccess) {
     Either<int,std::string> result = Either<int,std::string>::left(0);
     deferred->onComplete([&result, &signal](auto value) {
         result = value;
-        signal.set_value();
+        signal.notify();
     });
 
     promise->success(123);
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(result.get_left(), 123);
 }
 
 TEST_P(DeferredTest, PromiseOnCompleteError) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
@@ -176,17 +175,17 @@ TEST_P(DeferredTest, PromiseOnCompleteError) {
     Either<int,std::string> result = Either<int,std::string>::left(0);
     deferred->onComplete([&result, &signal](auto value) {
         result = value;
-        signal.set_value();
+        signal.notify();
     });
 
     promise->error("broke");
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(result.get_right(), "broke");
 }
 
 TEST_P(DeferredTest, PromiseOnSuccess) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
@@ -194,17 +193,17 @@ TEST_P(DeferredTest, PromiseOnSuccess) {
     int result = 0;
     deferred->onSuccess([&result, &signal](auto value) {
         result = value;
-        signal.set_value();
+        signal.notify();
     });
 
     promise->success(123);
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(result, 123);
 }
 
 TEST_P(DeferredTest, PromiseOnError) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
@@ -212,11 +211,11 @@ TEST_P(DeferredTest, PromiseOnError) {
     std::string result = "not called";
     deferred->onError([&result, &signal](auto value) {
         result = value;
-        signal.set_value();
+        signal.notify();
     });
 
     promise->error("broke");
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(result, "broke");
 }
@@ -245,19 +244,19 @@ TEST_P(DeferredTest, PromiseAwaitSyncError) {
 }
 
 TEST_P(DeferredTest, PromiseAwaitAsync) {
-    std::promise<void> started;
+    TestSignal started;
 
     auto promise = Promise<int,std::string>::create(sched);
     auto deferred = Deferred<int,std::string>::forPromise(promise);
     int value;
 
     std::thread backgroundAwait([&value, &started, &deferred]() {
-        started.set_value();
+        started.notify();
         value = deferred->await();
     });
 
     // Wait for background thread to get started
-    started.get_future().wait();
+    started.wait();
 
     // Complete the promise after a small sleep (to be triple sure that
     // the await is running).

--- a/test/cask/scheduler/TestScheduler.cpp
+++ b/test/cask/scheduler/TestScheduler.cpp
@@ -5,7 +5,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <future>
 #include "gtest/gtest.h"
 #include "cask/Deferred.hpp"
 #include "cask/Task.hpp"
@@ -23,13 +22,13 @@ TEST_P(SchedulerTest, IdlesAtStart) {
 }
 
 TEST_P(SchedulerTest, SubmitSingle) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     sched->submit([&signal] {
-        signal.set_value();
+        signal.notify();
     });
 
-    signal.get_future().wait();
+    signal.wait();
     
     awaitIdle();
 }
@@ -65,13 +64,13 @@ TEST_P(SchedulerTest, SubmitBulk) {
 }
 
 TEST_P(SchedulerTest, SubmitAfter) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto before = std::chrono::high_resolution_clock::now();
     sched->submitAfter(25, [&signal] {
-        signal.set_value();
+        signal.notify();
     });
-    signal.get_future().wait();
+    signal.wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;
@@ -83,11 +82,11 @@ TEST_P(SchedulerTest, SubmitAfter) {
 }
 
 TEST_P(SchedulerTest, SubmitAfterCancel) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     int cancel_counter = 0;
     auto firstHandle = sched->submitAfter(25, []{});
-    auto secondHandle = sched->submitAfter(25, [&signal] { signal.set_value(); });
+    auto secondHandle = sched->submitAfter(25, [&signal] { signal.notify(); });
 
     firstHandle->onCancel([&cancel_counter]{ cancel_counter++; });
     secondHandle->onCancel([&cancel_counter]{ cancel_counter++; });
@@ -96,24 +95,24 @@ TEST_P(SchedulerTest, SubmitAfterCancel) {
     firstHandle->cancel();
     firstHandle->cancel();
 
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(cancel_counter, 1);
     awaitIdle();
 }
 
 TEST_P(SchedulerTest, RegistersCallbackAfterCancelled) {
-    std::promise<void> signal;
+    TestSignal signal;
 
     int cancel_counter = 0;
     auto firstHandle = sched->submitAfter(25, []{});
-    auto secondHandle = sched->submitAfter(25, [&signal] { signal.set_value(); });
+    auto secondHandle = sched->submitAfter(25, [&signal] { signal.notify(); });
 
     firstHandle->cancel();
     firstHandle->onCancel([&cancel_counter]{ cancel_counter++; });
     secondHandle->onCancel([&cancel_counter]{ cancel_counter++; });
 
-    signal.get_future().wait();
+    signal.wait();
 
     EXPECT_EQ(cancel_counter, 1);
     awaitIdle();
@@ -121,17 +120,17 @@ TEST_P(SchedulerTest, RegistersCallbackAfterCancelled) {
 
 TEST_P(SchedulerTest, RunsShutdownCallbackAfterTimerTaskCompletion) {
     bool shutdown = false;
-    std::promise<void> shutdown_signal;
+    TestSignal shutdown_signal;
 
     auto before = std::chrono::high_resolution_clock::now();
     auto cancelable = sched->submitAfter(25, [] {});
 
     cancelable->onShutdown([&shutdown, &shutdown_signal] {
         shutdown = true;
-        shutdown_signal.set_value();
+        shutdown_signal.notify();
     });
 
-    shutdown_signal.get_future().wait();
+    shutdown_signal.wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;
@@ -145,14 +144,14 @@ TEST_P(SchedulerTest, RunsShutdownCallbackAfterTimerTaskCompletion) {
 
 TEST_P(SchedulerTest, RunsShutdownImmediatelyCallbackIfTimerAlreadyFired) {
     bool shutdown = false;
-    std::promise<void> signal;
+    TestSignal signal;
 
     auto before = std::chrono::high_resolution_clock::now();
     auto cancelable = sched->submitAfter(25, [&signal] {
-        signal.set_value();
+        signal.notify();
     });
 
-    signal.get_future().wait();
+    signal.wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;

--- a/test/cask/scheduler/TestScheduler.cpp
+++ b/test/cask/scheduler/TestScheduler.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include "gtest/gtest.h"
 #include "cask/Deferred.hpp"
 #include "cask/Task.hpp"
@@ -22,14 +23,13 @@ TEST_P(SchedulerTest, IdlesAtStart) {
 }
 
 TEST_P(SchedulerTest, SubmitSingle) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
-    sched->submit([&mutex] {
-        mutex.unlock();
+    sched->submit([&signal] {
+        signal.set_value();
     });
 
-    mutex.lock();
+    signal.get_future().wait();
     
     awaitIdle();
 }
@@ -65,14 +65,13 @@ TEST_P(SchedulerTest, SubmitBulk) {
 }
 
 TEST_P(SchedulerTest, SubmitAfter) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto before = std::chrono::high_resolution_clock::now();
-    sched->submitAfter(25, [&mutex] {
-        mutex.unlock();
+    sched->submitAfter(25, [&signal] {
+        signal.set_value();
     });
-    mutex.lock();
+    signal.get_future().wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;
@@ -84,12 +83,11 @@ TEST_P(SchedulerTest, SubmitAfter) {
 }
 
 TEST_P(SchedulerTest, SubmitAfterCancel) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     int cancel_counter = 0;
     auto firstHandle = sched->submitAfter(25, []{});
-    auto secondHandle = sched->submitAfter(25, [&mutex] { mutex.unlock(); });
+    auto secondHandle = sched->submitAfter(25, [&signal] { signal.set_value(); });
 
     firstHandle->onCancel([&cancel_counter]{ cancel_counter++; });
     secondHandle->onCancel([&cancel_counter]{ cancel_counter++; });
@@ -98,25 +96,24 @@ TEST_P(SchedulerTest, SubmitAfterCancel) {
     firstHandle->cancel();
     firstHandle->cancel();
 
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(cancel_counter, 1);
     awaitIdle();
 }
 
 TEST_P(SchedulerTest, RegistersCallbackAfterCancelled) {
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     int cancel_counter = 0;
     auto firstHandle = sched->submitAfter(25, []{});
-    auto secondHandle = sched->submitAfter(25, [&mutex] { mutex.unlock(); });
+    auto secondHandle = sched->submitAfter(25, [&signal] { signal.set_value(); });
 
     firstHandle->cancel();
     firstHandle->onCancel([&cancel_counter]{ cancel_counter++; });
     secondHandle->onCancel([&cancel_counter]{ cancel_counter++; });
 
-    mutex.lock();
+    signal.get_future().wait();
 
     EXPECT_EQ(cancel_counter, 1);
     awaitIdle();
@@ -124,19 +121,17 @@ TEST_P(SchedulerTest, RegistersCallbackAfterCancelled) {
 
 TEST_P(SchedulerTest, RunsShutdownCallbackAfterTimerTaskCompletion) {
     bool shutdown = false;
-    std::mutex shutdown_mutex;
-
-    shutdown_mutex.lock();
+    std::promise<void> shutdown_signal;
 
     auto before = std::chrono::high_resolution_clock::now();
     auto cancelable = sched->submitAfter(25, [] {});
 
-    cancelable->onShutdown([&shutdown, &shutdown_mutex] {
+    cancelable->onShutdown([&shutdown, &shutdown_signal] {
         shutdown = true;
-        shutdown_mutex.unlock();
+        shutdown_signal.set_value();
     });
 
-    shutdown_mutex.lock();
+    shutdown_signal.get_future().wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;
@@ -150,15 +145,14 @@ TEST_P(SchedulerTest, RunsShutdownCallbackAfterTimerTaskCompletion) {
 
 TEST_P(SchedulerTest, RunsShutdownImmediatelyCallbackIfTimerAlreadyFired) {
     bool shutdown = false;
-    std::mutex mutex;
-    mutex.lock();
+    std::promise<void> signal;
 
     auto before = std::chrono::high_resolution_clock::now();
-    auto cancelable = sched->submitAfter(25, [&mutex] {
-        mutex.unlock();
+    auto cancelable = sched->submitAfter(25, [&signal] {
+        signal.set_value();
     });
 
-    mutex.lock();
+    signal.get_future().wait();
     auto after = std::chrono::high_resolution_clock::now();
 
     auto delta = after - before;


### PR DESCRIPTION
This change resolve a myriad of tsan-discovered correctness issues in cask. While I've not seen any of them create issues in the field, regardless they should be resolved.

BlockPool (include/cask/pool/BlockPool.hpp):
- Racy read of old_head.ptr->next in allocate(): a concurrent pop/push could mutate next while it was being read. Made Block::next a std::atomic<Block*> with relaxed load/store (ordering is provided by the acquire/release CAS on free_blocks).
- Missing happens-before on chunk publication: the relaxed head load in allocate() did not synchronize with the release-CAS in allocate_chunk(), so dereferencing a freshly published block raced with chunk construction. The head load (and CAS failure ordering) is now acquire.

FiberImpl (include/cask/fiber/FiberImpl.hpp):
- racerFinished() blindly stored RUNNING into the fiber state instead of acquiring ownership, allowing two threads to "own" RUNNING simultaneously when a concurrent cancel() held it. This was the root cause of races on FiberValue (setValue/setError vs setCanceled) and continuationStack (push vs empty). It locks and transitions RACING -> RUNNING so that any concurrent cancel is serialized. It then bails out if the fiber already completed.
- Sloppy atomic re-reads in resumeUnsafe() and cancel(): conditions re-read the atomic state instead of using the captured value, making the ownership CAS only correct by luck. Both now compare against the captured current_state consistently.
- Data race on last_used_scheduler: the weak_ptr was assigned by resume/reschedule on one thread while cancel() called lock() on another (concurrent lock() and assignment on a weak_ptr is UB). All access now goes through mutex-guarded setLastScheduler() / getLastScheduler() helpers.

Tests (TestPromiseDeferred.cpp, TestScheduler.cpp):
- Replaced the lock-then-unlock-from-another-thread std::mutex signaling pattern with a more functionally correct signal using a mutex and condition variable.