### PR TITLE
perf: force move semantics in ReadyQueue

### DIFF
--- a/bench/BenchSchedulerFlatMap.cpp
+++ b/bench/BenchSchedulerFlatMap.cpp
@@ -1,0 +1,109 @@
+//          Copyright Tango Tango, Inc. 2020 - 2025.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include <benchmark/benchmark.h>
+#include "cask/Task.hpp"
+#include "cask/scheduler/SingleThreadScheduler.hpp"
+#include "cask/scheduler/WorkStealingScheduler.hpp"
+
+using cask::Task;
+using cask::scheduler::SingleThreadScheduler;
+using cask::scheduler::WorkStealingScheduler;
+
+// These benchmarks mirror BenchFlatMap but execute on a real scheduler,
+// with periodic asyncBoundary() steps so the fiber cedes and is re-queued
+// through the scheduler's ReadyQueue rather than running synchronously.
+
+namespace {
+
+Task<int> buildCedingChain(int chain_length, int cede_every) {
+    Task<int> task = Task<int>::pure(0);
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template flatMap<int>([](int value) {
+            return Task<int>::pure(value + 1);
+        });
+        if (cede_every > 0 && (i + 1) % cede_every == 0) {
+            task = task.asyncBoundary();
+        }
+    }
+    return task;
+}
+
+void runChainOnScheduler(benchmark::State& state, const std::shared_ptr<cask::Scheduler>& sched, int cede_every) {
+    const int chain_length = static_cast<int>(state.range(0));
+    auto task = buildCedingChain(chain_length, cede_every);
+
+    for (auto _ : state) {
+        auto result = task.run(sched)->await();
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+} // namespace
+
+// Pure flatMap chain on a real scheduler with no cedes — the synchronous
+// fast path. ReadyQueue is touched only once for the initial submit.
+static void BM_SchedFlatMap_SingleThread_NoCede(benchmark::State& state) {
+    auto sched = std::make_shared<SingleThreadScheduler>();
+    runChainOnScheduler(state, sched, 0);
+}
+BENCHMARK(BM_SchedFlatMap_SingleThread_NoCede)->Arg(64)->Arg(256);
+
+// Cede after every operation — maximum ReadyQueue pressure. Every step of
+// the chain round-trips through push_back/pop_front.
+static void BM_SchedFlatMap_SingleThread_CedeEvery1(benchmark::State& state) {
+    auto sched = std::make_shared<SingleThreadScheduler>();
+    runChainOnScheduler(state, sched, 1);
+}
+BENCHMARK(BM_SchedFlatMap_SingleThread_CedeEvery1)->Arg(64)->Arg(256);
+
+// Cede every 16 operations — a mixed workload closer to real usage where
+// most work is synchronous with occasional fairness yields.
+static void BM_SchedFlatMap_SingleThread_CedeEvery16(benchmark::State& state) {
+    auto sched = std::make_shared<SingleThreadScheduler>();
+    runChainOnScheduler(state, sched, 16);
+}
+BENCHMARK(BM_SchedFlatMap_SingleThread_CedeEvery16)->Arg(64)->Arg(256);
+
+// Same shapes on the work stealing scheduler, where requeues may also
+// involve steal_from between worker queues.
+static void BM_SchedFlatMap_WorkStealing_NoCede(benchmark::State& state) {
+    auto sched = std::make_shared<WorkStealingScheduler>(4);
+    runChainOnScheduler(state, sched, 0);
+}
+BENCHMARK(BM_SchedFlatMap_WorkStealing_NoCede)->Arg(64)->Arg(256);
+
+static void BM_SchedFlatMap_WorkStealing_CedeEvery1(benchmark::State& state) {
+    auto sched = std::make_shared<WorkStealingScheduler>(4);
+    runChainOnScheduler(state, sched, 1);
+}
+BENCHMARK(BM_SchedFlatMap_WorkStealing_CedeEvery1)->Arg(64)->Arg(256);
+
+static void BM_SchedFlatMap_WorkStealing_CedeEvery16(benchmark::State& state) {
+    auto sched = std::make_shared<WorkStealingScheduler>(4);
+    runChainOnScheduler(state, sched, 16);
+}
+BENCHMARK(BM_SchedFlatMap_WorkStealing_CedeEvery16)->Arg(64)->Arg(256);
+
+// Many concurrent fibers all ceding — keeps the ReadyQueue populated so
+// pops happen under load rather than ping-ponging an empty queue.
+static void BM_SchedFlatMap_SingleThread_ManyFibers(benchmark::State& state) {
+    const int num_fibers = static_cast<int>(state.range(0));
+    auto sched = std::make_shared<SingleThreadScheduler>();
+    auto task = buildCedingChain(32, 1);
+
+    for (auto _ : state) {
+        std::vector<cask::FiberRef<int, std::any>> fibers;
+        fibers.reserve(num_fibers);
+        for (int i = 0; i < num_fibers; ++i) {
+            fibers.push_back(task.run(sched));
+        }
+        for (auto& fiber : fibers) {
+            auto result = fiber->await();
+            benchmark::DoNotOptimize(result);
+        }
+    }
+}
+BENCHMARK(BM_SchedFlatMap_SingleThread_ManyFibers)->Arg(8);

--- a/bench/BenchSchedulerFlatMap.cpp
+++ b/bench/BenchSchedulerFlatMap.cpp
@@ -4,10 +4,11 @@
 //          https://www.boost.org/LICENSE_1_0.txt)
 
 #include <benchmark/benchmark.h>
+#include <any>
+#include <vector>
 #include "cask/Task.hpp"
 #include "cask/scheduler/SingleThreadScheduler.hpp"
 #include "cask/scheduler/WorkStealingScheduler.hpp"
-
 using cask::Task;
 using cask::scheduler::SingleThreadScheduler;
 using cask::scheduler::WorkStealingScheduler;

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -6,6 +6,7 @@ if get_option('build_benchmarks')
         'BenchFiberOp.cpp',
         'BenchFlatMap.cpp',
         'BenchPool.cpp',
+        'BenchSchedulerFlatMap.cpp',
         'main.cpp'
     ]
 

--- a/src/cask/scheduler/ReadyQueue.cpp
+++ b/src/cask/scheduler/ReadyQueue.cpp
@@ -30,7 +30,7 @@ std::optional<std::function<void()>> ReadyQueue::push_front(const std::function<
     if (ready_queue.size() + 1 > max_queue_size) {
         // Pop an item from the back of the queue and return it
         // as overflow, then push this item to the front.
-        auto overflow = ready_queue.back();
+        auto overflow = std::move(ready_queue.back());
         ready_queue.pop_back();
         ready_queue.emplace_front(task);
         return overflow;
@@ -75,7 +75,7 @@ std::optional<std::function<void()>> ReadyQueue::pop_front() {
     if(ready_queue.empty()) {
         return std::nullopt;
     } else {
-        auto task = ready_queue.front();
+        auto task = std::move(ready_queue.front());
         ready_queue.pop_front();
         memoized_queue_size.fetch_sub(1, std::memory_order_relaxed);
         return task;
@@ -87,7 +87,7 @@ std::optional<std::function<void()>> ReadyQueue::pop_back() {
     if(ready_queue.empty()) {
         return std::nullopt;
     } else {
-        auto task = ready_queue.back();
+        auto task = std::move(ready_queue.back());
         ready_queue.pop_back();
         memoized_queue_size.fetch_sub(1, std::memory_order_relaxed);
         return task;
@@ -101,9 +101,9 @@ bool ReadyQueue::steal_from(ReadyQueue& victim) {
     if (ready_queue.size() >= max_queue_size || victim.ready_queue.empty()) {
         return false;
     } else {
-        auto task = victim.ready_queue.back();
+        auto task = std::move(victim.ready_queue.back());
         victim.ready_queue.pop_back();
-        ready_queue.emplace_front(task);
+        ready_queue.emplace_front(std::move(task));
         memoized_queue_size.fetch_add(1, std::memory_order_relaxed);
         victim.memoized_queue_size.fetch_sub(1, std::memory_order_relaxed);
         work_available.notify_one();

--- a/src/cask/scheduler/SingleThreadScheduler.cpp
+++ b/src/cask/scheduler/SingleThreadScheduler.cpp
@@ -323,7 +323,7 @@ bool SingleThreadScheduler::steal_unsafe(const std::shared_ptr<SchedulerControlD
         requested_amount--;
 
         if (auto task = control_data->ready_queue.pop_front()) {
-            requestor_ready_queue.emplace_back(*task);
+            requestor_ready_queue.emplace_back(std::move(*task));
             work_stolen = true;
         } else {
             break;


### PR DESCRIPTION
This change optimizes ReadyQueue through the application of explicit move semantics. This provides a significant performance boost when microbenchmarking ReadyQueue itself, but on modest improvements in real-world workloads. In testing a few percent improvement was seen in extremely cede-heavy workflows that stressed the ReadyQueue.

Even though the gains are minimal, the change is straightforward so going ahead and moving forward with it.