### PR TITLE
feat: optimize erased value storage and moving

### DIFF
--- a/include/cask/Either.hpp
+++ b/include/cask/Either.hpp
@@ -72,40 +72,48 @@ public:
     constexpr bool is_right() const;
 
     /**
-     * Attempt to get the left result. Can throw if this either
-     * is holding a right result instead - and thus should be
-     * be guarded by a call to `is_left` or `!is_right` to determine
-     * the state of this either.
+     * Get the left value held by this either.
      *
-     * @return The left value or throws an exception.
+     * @pre This either must be holding a left value. Guard the call with
+     *      `is_left()` (or `!is_right()`); calling this when the either
+     *      holds a right value is undefined behavior - it does NOT throw.
+     *
+     * @return A copy of the left value.
      */
     constexpr L get_left() const&;
 
     /**
-     * Attempt to get the left result, moving it out of this either.
-     * Only callable on rvalues - the either is left holding a
-     * moved-from value.
+     * Get the left value, moving it out of this either. Only callable on
+     * rvalues; the either is left holding a moved-from value.
      *
-     * @return The left value or throws an exception.
+     * @pre This either must be holding a left value. Guard the call with
+     *      `is_left()` (or `!is_right()`); calling this when the either
+     *      holds a right value is undefined behavior - it does NOT throw.
+     *
+     * @return The left value, moved out of this either.
      */
     constexpr L get_left() &&;
 
     /**
-     * Attempt to get the right result. Can throw if this either
-     * is holding a right result instead - and thus should be
-     * be guarded by a call to `is_right` or `!is_left` to determine
-     * the state of this either.
+     * Get the right value held by this either.
      *
-     * @return The right value or throws an exception.
+     * @pre This either must be holding a right value. Guard the call with
+     *      `is_right()` (or `!is_left()`); calling this when the either
+     *      holds a left value is undefined behavior - it does NOT throw.
+     *
+     * @return A copy of the right value.
      */
     constexpr R get_right() const&;
 
     /**
-     * Attempt to get the right result, moving it out of this either.
-     * Only callable on rvalues - the either is left holding a
-     * moved-from value.
+     * Get the right value, moving it out of this either. Only callable on
+     * rvalues; the either is left holding a moved-from value.
      *
-     * @return The right value or throws an exception.
+     * @pre This either must be holding a right value. Guard the call with
+     *      `is_right()` (or `!is_left()`); calling this when the either
+     *      holds a left value is undefined behavior - it does NOT throw.
+     *
+     * @return The right value, moved out of this either.
      */
     constexpr R get_right() &&;
 

--- a/include/cask/Either.hpp
+++ b/include/cask/Either.hpp
@@ -7,6 +7,7 @@
 #define _CASK_EITHER_H_
 
 #include <optional>
+#include <utility>
 
 namespace cask {
 
@@ -78,7 +79,16 @@ public:
      *
      * @return The left value or throws an exception.
      */
-    constexpr L get_left() const;
+    constexpr L get_left() const&;
+
+    /**
+     * Attempt to get the left result, moving it out of this either.
+     * Only callable on rvalues - the either is left holding a
+     * moved-from value.
+     *
+     * @return The left value or throws an exception.
+     */
+    constexpr L get_left() &&;
 
     /**
      * Attempt to get the right result. Can throw if this either
@@ -88,7 +98,16 @@ public:
      *
      * @return The right value or throws an exception.
      */
-    constexpr R get_right() const;
+    constexpr R get_right() const&;
+
+    /**
+     * Attempt to get the right result, moving it out of this either.
+     * Only callable on rvalues - the either is left holding a
+     * moved-from value.
+     *
+     * @return The right value or throws an exception.
+     */
+    constexpr R get_right() &&;
 
     constexpr Either<L,R>(const Either<L,R>&) = default;
     constexpr Either<L,R>(Either<L,R>&&) noexcept = default;
@@ -140,13 +159,23 @@ constexpr bool Either<L,R>::is_right() const {
 }
 
 template <class L, class R>
-constexpr L Either<L,R>::get_left() const {
+constexpr L Either<L,R>::get_left() const& {
     return *leftValue; // NOLINT(bugprone-unchecked-optional-access)
 }
 
 template <class L, class R>
-constexpr R Either<L,R>::get_right() const {
+constexpr L Either<L,R>::get_left() && {
+    return std::move(*leftValue); // NOLINT(bugprone-unchecked-optional-access)
+}
+
+template <class L, class R>
+constexpr R Either<L,R>::get_right() const& {
     return *rightValue; // NOLINT(bugprone-unchecked-optional-access)
+}
+
+template <class L, class R>
+constexpr R Either<L,R>::get_right() && {
+    return std::move(*rightValue); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 } // namespace cask

--- a/include/cask/Erased.hpp
+++ b/include/cask/Erased.hpp
@@ -379,7 +379,7 @@ inline Erased& Erased::operator=(T&& value) noexcept {
     using DecayedT = std::decay_t<T>;
     if(state == state_for<DecayedT>()) {
         if constexpr (erased::trivial_sbo<DecayedT>) {
-            std::memcpy(inline_ptr(), &value, sizeof(DecayedT));
+            ::new (inline_ptr()) DecayedT(std::forward<T>(value));
         } else if constexpr (erased::fits_sbo<DecayedT>) {
             *static_cast<DecayedT*>(inline_ptr()) = std::forward<T>(value);
         } else {

--- a/include/cask/Erased.hpp
+++ b/include/cask/Erased.hpp
@@ -8,15 +8,132 @@
 
 #include "cask/Config.hpp"
 
-#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <new>
 #include <stdexcept>
-#include <functional>
 #include <type_traits>
-#include <typeinfo>
-#include <stack>
+#include <utility>
 #include "cask/pool/InternalPool.hpp"
 
 namespace cask {
+
+namespace erased {
+
+// The inline buffer is pointer-aligned. Types with stricter alignment
+// requirements (e.g. 16-byte-aligned SIMD or `long double` types) simply
+// fail `fits_sbo` below and are pool-allocated instead - keeping the
+// buffer from forcing padding that would push Erased past one cache line.
+constexpr std::size_t sbo_align = alignof(void*);
+
+// Reference held to the pool while a pool-allocated value is alive.
+using PoolRef = std::shared_ptr<Pool>;
+
+// Storage for a pool-allocated value: the value pointer and the pool
+// reference that keeps the pool alive while the value exists.
+struct HeapValue {
+    void* ptr;
+    PoolRef pool;
+};
+
+// Non-buffer overhead of an Erased instance: just the tagged
+// operations-table pointer. The value pointer and pool reference are NOT
+// overhead - they share storage with the inline buffer, since a value is
+// held in exactly one of the two.
+constexpr std::size_t erased_overhead = sizeof(std::uintptr_t);
+
+// Size the inline buffer so a complete Erased fills exactly one cache line
+// on the configured architecture (e.g. 56 bytes of buffer for 64-byte
+// lines, 120 for 128-byte lines). For pathologically small configured
+// line sizes the buffer still needs to be at least as large as the heap
+// value bookkeeping it shares storage with.
+constexpr std::size_t sbo_size =
+    config::cache_line_size > erased_overhead + sizeof(HeapValue)
+        ? config::cache_line_size - erased_overhead
+        : sizeof(HeapValue);
+
+// A type is stored inline when it fits the buffer and can be moved
+// without throwing (Erased's move operations are noexcept and must
+// relocate inline values).
+template <typename T>
+constexpr bool fits_sbo =
+    sizeof(T) <= sbo_size &&
+    alignof(T) <= sbo_align &&
+    std::is_nothrow_move_constructible<T>::value;
+
+// A trivial inline type needs no operations table at all: copies and
+// moves are a memcpy of the buffer and destruction is a no-op. No
+// per-type code or data is generated for these types.
+template <typename T>
+constexpr bool trivial_sbo =
+    fits_sbo<T> &&
+    std::is_trivially_copyable<T>::value &&
+    std::is_trivially_destructible<T>::value;
+
+// In-place operations used for non-trivial values stored in the inline buffer.
+struct InlineOps {
+    void (*destroy)(void* ptr) noexcept;
+    void (*copy_construct)(void* dest, const void* src);
+    void (*move_construct)(void* dest, void* src);
+};
+
+// Pool-backed operations used for values too large for the inline buffer.
+struct PoolOps {
+    void* (*copy)(const void* src, const PoolRef& pool);
+    void (*destroy)(void* ptr, const PoolRef& pool);
+};
+
+/**
+ * A static per-type operations table describing how to destroy, copy, and
+ * move a type-erased value when its static type is not available (Erased's
+ * own special members). Everything that CAN be derived from the caller's T
+ * (`get`, construction, the assignment fast path) is resolved at compile
+ * time and never touches this table.
+ * 
+ * A given type only ever uses one storage strategy - inline or pool - so
+ * the two operation sets share a union and only the relevant set is
+ * instantiated for each type. Which member is active (and whether the type
+ * is trivial) is encoded in the low bits of the pointer to this table
+ * carried by each Erased - see Erased::State below.
+ */
+// Alignment for TypeOps tables: at least 4 so the two low bits of a
+// table pointer are guaranteed free for tagging on every supported
+// architecture (x86_64/aarch64 naturally align to 8; armv7l and mipsel
+// align function pointers to 4). alignas may not weaken natural
+// alignment, so take the max.
+constexpr std::size_t type_ops_align = alignof(PoolOps) > 4 ? alignof(PoolOps) : 4;
+
+union alignas(type_ops_align) TypeOps {
+    constexpr explicit TypeOps(InlineOps ops) noexcept : inline_ops(ops) {}
+    constexpr explicit TypeOps(PoolOps ops) noexcept : pool_ops(ops) {}
+
+    InlineOps inline_ops;
+    PoolOps pool_ops;
+};
+
+// `constexpr` (rather than `const`) guarantees constant-initialization, so
+// the table is valid even for Erased values constructed during the dynamic
+// initialization of other globals (no static-initialization-order hazard).
+template <typename T>
+inline constexpr TypeOps ops_for = [] {
+    static_assert(!trivial_sbo<T>, "trivial inline types need no operations table");
+    if constexpr (fits_sbo<T>) {
+        return TypeOps(InlineOps{
+            [](void* ptr) noexcept { static_cast<T*>(ptr)->~T(); },
+            [](void* dest, const void* src) { ::new (dest) T(*static_cast<const T*>(src)); },
+            [](void* dest, void* src) { ::new (dest) T(std::move(*static_cast<T*>(src))); }
+        });
+    } else {
+        return TypeOps(PoolOps{
+            [](const void* src, const PoolRef& pool) -> void* { return pool->allocate<T>(*static_cast<const T*>(src)); },
+            [](void* ptr, const PoolRef& pool) { pool->deallocate<T>(static_cast<T*>(ptr)); }
+        });
+    }
+}();
+
+} // namespace erased
 
 /**
  * A holder for a type-erased value. This type can hold any other type and will
@@ -25,6 +142,17 @@ namespace cask {
  * and validating type information at runtime, this type assumes that the caller
  * _really_ knows what they are doing. In the context of cask, it is used by
  * `Task` since its template layer validates these types at compile time.
+ * 
+ * That "caller knows the type" contract is leaned on hard as an optimization:
+ * no RTTI is stored or compared, and every operation where the caller supplies
+ * T (construction, `get`, assignment) resolves its storage strategy entirely at
+ * compile time. Small values (the common case on the fiber hot path - ints,
+ * `None`, `shared_ptr`s and the like) are stored in an inline buffer, requiring
+ * no allocation and no interaction with the global memory pool at all -
+ * trivially-copyable ones generate no per-type code or data whatsoever. Larger
+ * values are allocated from the pool, with a reference to the pool held for
+ * exactly as long as the value lives - the pool is reference counted and is
+ * destroyed deterministically when its last user releases it.
  * 
  * Does the idea of a type blowing up on you because you don't pass correct
  * type arguments to it later scare you? Good. Don't use this. It serves a very
@@ -85,130 +213,227 @@ public:
 
     ~Erased();
 private:
-    std::shared_ptr<Pool> pool;
-    void* data;
-    void (*deleter)(void*, const std::shared_ptr<Pool>& pool);
-    void* (*copier)(void*, const std::shared_ptr<Pool>& pool);
-    const std::type_info * info;
+    static constexpr std::size_t sbo_size = erased::sbo_size;
+    static constexpr std::size_t sbo_align = erased::sbo_align;
+
+    using PoolRef = erased::PoolRef;
+    using HeapValue = erased::HeapValue;
+
+    // The entire per-instance bookkeeping is a single tagged pointer:
+    //
+    //   0                            - empty, no value held
+    //   (size << 2) | trivial_tag    - trivial value of `size` bytes in the
+    //                                  inline buffer (no operations table
+    //                                  exists or is needed; the value's size
+    //                                  rides in the bits a table pointer
+    //                                  would otherwise occupy)
+    //   TypeOps*                     - non-trivial value in the inline buffer
+    //   TypeOps* | pooled_flag       - pool-allocated value
+    //
+    // TypeOps holds function pointers so its alignment guarantees the low
+    // bits of a real table pointer are zero. Trivial states never set
+    // pooled_flag because the size is shifted past it.
+    using State = std::uintptr_t;
+
+    static constexpr State trivial_tag = 0x1;
+    static constexpr State pooled_flag = 0x2;
+    static constexpr State ptr_mask = ~static_cast<State>(0x3);
+    static constexpr State size_shift = 2;
+
+    static_assert(alignof(erased::TypeOps) >= 4, "TypeOps alignment must leave two low tag bits free");
+
+    // The state a value of type T is always stored with - fully resolved
+    // at compile time (the table address folds to a link-time constant).
+    template <typename T>
+    static State state_for() noexcept {
+        if constexpr (erased::trivial_sbo<T>) {
+            return trivial_tag | (static_cast<State>(sizeof(T)) << size_shift);
+        } else if constexpr (erased::fits_sbo<T>) {
+            return reinterpret_cast<State>(&erased::ops_for<T>);
+        } else {
+            return reinterpret_cast<State>(&erased::ops_for<T>) | pooled_flag;
+        }
+    }
+
+    const erased::TypeOps* table() const noexcept {
+        return reinterpret_cast<const erased::TypeOps*>(state & ptr_mask); // NOLINT(performance-no-int-to-ptr)
+    }
+
+    // The byte size of a held trivial value. Only meaningful when
+    // `state & trivial_tag` is set.
+    std::size_t trivial_size() const noexcept {
+        return static_cast<std::size_t>(state >> size_shift);
+    }
+
+    // A value lives in exactly one of these: small values are constructed
+    // directly in the inline buffer, while large values live in the pool
+    // with the value pointer and pool reference held here for the value's
+    // lifetime. Which member is active is encoded in `state` - no
+    // per-instance discriminator or value pointer is needed. The heap
+    // member's lifetime is managed manually with placement-new / explicit
+    // destroy.
+    union Storage {
+        alignas(sbo_align) unsigned char buffer[sbo_size];
+        HeapValue heap;
+
+        Storage() noexcept {}
+        ~Storage() {}
+    };
+
+    void* inline_ptr() const noexcept {
+        return const_cast<void*>(static_cast<const void*>(&storage.buffer)); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
+    // Activate / deactivate the heap member of the union.
+    void emplace_heap_copy(const Erased& other) noexcept {
+        HeapValue& heap = *(::new (static_cast<void*>(&storage.heap)) HeapValue{nullptr, other.storage.heap.pool});
+        heap.ptr = table()->pool_ops.copy(other.storage.heap.ptr, heap.pool);
+    }
+
+    void emplace_heap_move(Erased& other) noexcept {
+        ::new (static_cast<void*>(&storage.heap)) HeapValue{other.storage.heap.ptr, std::move(other.storage.heap.pool)};
+        other.destroy_heap();
+    }
+
+    void destroy_heap() noexcept {
+        storage.heap.~HeapValue();
+    }
+
+    // Type-erased copy/move used by Erased's own special members, where no
+    // static type information is available. `state` must already be set.
+    void copy_value_from(const Erased& other) noexcept {
+        if(state & trivial_tag) {
+            std::memcpy(&storage.buffer, &other.storage.buffer, trivial_size());
+        } else if(state & pooled_flag) {
+            emplace_heap_copy(other);
+        } else {
+            table()->inline_ops.copy_construct(inline_ptr(), other.inline_ptr());
+        }
+    }
+
+    void move_value_from(Erased& other) noexcept {
+        if(state & trivial_tag) {
+            std::memcpy(&storage.buffer, &other.storage.buffer, trivial_size());
+        } else if(state & pooled_flag) {
+            emplace_heap_move(other);
+        } else {
+            table()->inline_ops.move_construct(inline_ptr(), other.inline_ptr());
+            table()->inline_ops.destroy(other.inline_ptr());
+        }
+    }
+
+    template <typename T, typename Arg>
+    void construct(Arg&& value) noexcept;
+
+    Storage storage;
+    State state;
 };
+
+template <typename T, typename Arg>
+inline void Erased::construct(Arg&& value) noexcept {
+    state = state_for<T>();
+    if constexpr (erased::fits_sbo<T>) {
+        ::new (inline_ptr()) T(std::forward<Arg>(value));
+    } else {
+        HeapValue& heap = *(::new (static_cast<void*>(&storage.heap)) HeapValue{nullptr, cask::pool::global_pool()});
+        heap.ptr = heap.pool->allocate<T>(std::forward<Arg>(value));
+    }
+}
 
 template <typename T, typename>
 inline Erased::Erased(const T& value) noexcept
-    : pool(cask::pool::global_pool())
-    , data(pool->allocate<T>(value))
-    , deleter([](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<T>(static_cast<T*>(ptr)); })
-    , copier([](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<T>(*(static_cast<T*>(ptr))); })
-    , info(&typeid(T))
-{}
+    : state(0)
+{
+    construct<T>(value);
+}
 
 template <typename T, typename>
 inline Erased::Erased(T&& value) noexcept
-    : pool(cask::pool::global_pool())
-    , data(pool->allocate<std::decay_t<T>>(std::forward<T>(value)))
-    , deleter([](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<std::decay_t<T>>(static_cast<std::decay_t<T>*>(ptr)); })
-    , copier([](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<std::decay_t<T>>(*(static_cast<std::decay_t<T>*>(ptr))); })
-    , info(&typeid(std::decay_t<T>))
-{}
+    : state(0)
+{
+    construct<std::decay_t<T>>(std::forward<T>(value));
+}
 
 template <typename T, typename>
 inline Erased& Erased::operator=(const T& value) noexcept {
-    if(data == nullptr) {
-        pool = cask::pool::global_pool();
-        data = pool->allocate<T>(value);
-        deleter = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<T>(static_cast<T*>(ptr)); };
-        copier = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<T>(*static_cast<T*>(ptr)); };
-        info = &typeid(T);
-    } else if(typeid(T) == *info) {
-        *static_cast<T*>(data) = value;
+    if(state == state_for<T>()) {
+        if constexpr (erased::trivial_sbo<T>) {
+            // Same-size trivial types share a state, so the buffer may hold
+            // a different (but equally trivial) type. Copy bytes rather
+            // than invoking T's assignment on possibly-mismatched storage.
+            std::memcpy(inline_ptr(), &value, sizeof(T));
+        } else if constexpr (erased::fits_sbo<T>) {
+            *static_cast<T*>(inline_ptr()) = value;
+        } else {
+            *static_cast<T*>(storage.heap.ptr) = value;
+        }
     } else {
-        deleter(data, pool);
-        pool = cask::pool::global_pool();
-        data = pool->allocate<T>(value);
-        deleter = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<T>(static_cast<T*>(ptr)); };
-        copier = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<T>(*static_cast<T*>(ptr)); };
-        info = &typeid(T);
+        reset();
+        construct<T>(value);
     }
-
     return *this;
 }
 
 template <typename T, typename>
 inline Erased& Erased::operator=(T&& value) noexcept {
     using DecayedT = std::decay_t<T>;
-    if(data == nullptr) {
-        pool = cask::pool::global_pool();
-        data = pool->allocate<DecayedT>(std::forward<T>(value));
-        deleter = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<DecayedT>(static_cast<DecayedT*>(ptr)); };
-        copier = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<DecayedT>(*static_cast<DecayedT*>(ptr)); };
-        info = &typeid(DecayedT);
-    } else if(typeid(DecayedT) == *info) {
-        *static_cast<DecayedT*>(data) = std::forward<T>(value);
+    if(state == state_for<DecayedT>()) {
+        if constexpr (erased::trivial_sbo<DecayedT>) {
+            std::memcpy(inline_ptr(), &value, sizeof(DecayedT));
+        } else if constexpr (erased::fits_sbo<DecayedT>) {
+            *static_cast<DecayedT*>(inline_ptr()) = std::forward<T>(value);
+        } else {
+            *static_cast<DecayedT*>(storage.heap.ptr) = std::forward<T>(value);
+        }
     } else {
-        deleter(data, pool);
-        pool = cask::pool::global_pool();
-        data = pool->allocate<DecayedT>(std::forward<T>(value));
-        deleter = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void { pool->deallocate<DecayedT>(static_cast<DecayedT*>(ptr)); };
-        copier = [](void* ptr, const std::shared_ptr<Pool>& pool) -> void* { return pool->allocate<DecayedT>(*static_cast<DecayedT*>(ptr)); };
-        info = &typeid(DecayedT);
+        reset();
+        construct<DecayedT>(std::forward<T>(value));
     }
-
     return *this;
 }
 
 template <typename T>
 inline T& Erased::get() const {
-    if(data != nullptr) {
-        return *(static_cast<T*>(data));
+    if(state != 0) {
+        // The caller's T is trusted to match the stored type (see the class
+        // docs), so the storage strategy is selected at compile time.
+        if constexpr (erased::fits_sbo<T>) {
+            return *static_cast<T*>(inline_ptr());
+        } else {
+            return *static_cast<T*>(storage.heap.ptr);
+        }
     } else {
         throw std::runtime_error("Tried to obtain value for empty Erased container.");
     }
 }
 
 inline Erased::Erased() noexcept
-    : pool()
-    , data(nullptr)
-    , deleter()
-    , copier()
-    , info(nullptr)
+    : state(0)
 {}
 
 inline Erased::Erased(const Erased& other) noexcept
-    : pool()
-    , data(nullptr)
-    , deleter()
-    , copier()
-    , info(other.info)
+    : state(other.state)
 {
-    if(other.data != nullptr) {
-        this->pool = other.pool;
-        this->deleter = other.deleter;
-        this->copier = other.copier;
-        this->data = other.copier(other.data, other.pool);
+    if(state != 0) {
+        copy_value_from(other);
     }
 }
 
 inline Erased::Erased(Erased&& other) noexcept
-    : pool(std::move(other.pool))
-    , data(other.data)
-    , deleter(other.deleter)
-    , copier(other.copier)
-    , info(other.info)
+    : state(other.state)
 {
-    other.data = nullptr;
-    other.deleter = nullptr;
-    other.copier = nullptr;
-    other.info = nullptr;
+    if(state != 0) {
+        move_value_from(other);
+        other.state = 0;
+    }
 }
 
 inline Erased& Erased::operator=(const Erased& other) noexcept {
     if(this != &other) {
         reset();
-        if(other.data != nullptr) {
-            this->pool = other.pool;
-            this->deleter = other.deleter;
-            this->copier = other.copier;
-            this->data = other.copier(other.data, other.pool);
-            this->info = other.info;
+        state = other.state;
+        if(state != 0) {
+            copy_value_from(other);
         }
     }
     return *this;
@@ -217,38 +442,34 @@ inline Erased& Erased::operator=(const Erased& other) noexcept {
 inline Erased& Erased::operator=(Erased&& other) noexcept {
     if(this != &other) {
         reset();
-        this->pool = std::move(other.pool);
-        this->data = other.data;
-        this->deleter = other.deleter;
-        this->copier = other.copier;
-        this->info = other.info;
-        other.data = nullptr;
-        other.deleter = nullptr;
-        other.copier = nullptr;
-        other.info = nullptr;
+        state = other.state;
+        if(state != 0) {
+            move_value_from(other);
+            other.state = 0;
+        }
     }
     return *this;
 }
 
 inline bool Erased::has_value() const noexcept {
-    return data != nullptr;
+    return state != 0;
 }
 
 inline void Erased::reset() noexcept {
-    if(data != nullptr) {
-        deleter(data, pool);
-        data = nullptr;
-        pool = nullptr;
+    if(state != 0) {
+        if(state & pooled_flag) {
+            table()->pool_ops.destroy(storage.heap.ptr, storage.heap.pool);
+            destroy_heap();
+        } else if(!(state & trivial_tag)) {
+            table()->inline_ops.destroy(inline_ptr());
+        }
+        state = 0;
     }
 }
 
-inline Erased::~Erased() { 
-    if(data != nullptr) {
-        deleter(data, pool);
-        data = nullptr;
-        pool = nullptr;
-    }
-} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks): delete is happening within the deleter lambda
+inline Erased::~Erased() {
+    reset();
+}
 
 } // namespace cask
 

--- a/include/cask/Erased.hpp
+++ b/include/cask/Erased.hpp
@@ -121,7 +121,7 @@ inline constexpr TypeOps ops_for = [] {
     static_assert(!trivial_sbo<T>, "trivial inline types need no operations table");
     if constexpr (fits_sbo<T>) {
         return TypeOps(InlineOps{
-            [](void* ptr) noexcept { static_cast<T*>(ptr)->~T(); },
+            [](void* ptr) noexcept { std::destroy_at(static_cast<T*>(ptr)); },
             [](void* dest, const void* src) { ::new (dest) T(*static_cast<const T*>(src)); },
             [](void* dest, void* src) { ::new (dest) T(std::move(*static_cast<T*>(src))); }
         });

--- a/include/cask/Erased.hpp
+++ b/include/cask/Erased.hpp
@@ -358,10 +358,10 @@ template <typename T, typename>
 inline Erased& Erased::operator=(const T& value) noexcept {
     if(state == state_for<T>()) {
         if constexpr (erased::trivial_sbo<T>) {
-            // Same-size trivial types share a state, so the buffer may hold
-            // a different (but equally trivial) type. Copy bytes rather
-            // than invoking T's assignment on possibly-mismatched storage.
-            std::memcpy(inline_ptr(), &value, sizeof(T));
+            // Same-size trivial types share a state, so the buffer may hold a
+            // different (but equally trivial) type. Reconstruct to ensure the
+            // correct object's lifetime is active in C++17.
+            ::new (inline_ptr()) T(value);
         } else if constexpr (erased::fits_sbo<T>) {
             *static_cast<T*>(inline_ptr()) = value;
         } else {

--- a/include/cask/Erased.hpp
+++ b/include/cask/Erased.hpp
@@ -122,7 +122,9 @@ inline constexpr TypeOps ops_for = [] {
     if constexpr (fits_sbo<T>) {
         return TypeOps(InlineOps{
             [](void* ptr) noexcept { std::destroy_at(static_cast<T*>(ptr)); },
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): type-erased relocation primitive; the (dest, src) order mirrors the standard placement-new/memcpy convention
             [](void* dest, const void* src) { ::new (dest) T(*static_cast<const T*>(src)); },
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): type-erased relocation primitive; the (dest, src) order mirrors the standard placement-new/memcpy convention
             [](void* dest, void* src) { ::new (dest) T(std::move(*static_cast<T*>(src))); }
         });
     } else {

--- a/include/cask/Pool.hpp
+++ b/include/cask/Pool.hpp
@@ -31,7 +31,12 @@ private:
 
 template <class T, class... Args>
 T* Pool::allocate(Args&&... args) {
-    if constexpr (sizeof(T) <= config::cache_line_size) {
+    // The block pools only guarantee alignof(std::max_align_t); types with
+    // stricter alignment go to (aligned) operator new, which honors any
+    // alignment in C++17.
+    if constexpr (alignof(T) > alignof(std::max_align_t)) {
+        return new T(std::forward<Args>(args)...);
+    } else if constexpr (sizeof(T) <= config::cache_line_size) {
         return small_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
     } else if constexpr (sizeof(T) <= config::cache_line_size * 2UL) {
         return medium_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
@@ -52,7 +57,9 @@ T* Pool::allocate(Args&&... args) {
 
 template <class T>
 void Pool::deallocate(T* ptr) {
-    if constexpr (sizeof(T) <= config::cache_line_size) {
+    if constexpr (alignof(T) > alignof(std::max_align_t)) {
+        delete ptr;
+    } else if constexpr (sizeof(T) <= config::cache_line_size) {
         return small_pool.template deallocate<T>(ptr);
     } else if constexpr (sizeof(T) <= config::cache_line_size * 2UL) {
         return medium_pool.template deallocate<T>(ptr);

--- a/include/cask/Pool.hpp
+++ b/include/cask/Pool.hpp
@@ -32,23 +32,22 @@ private:
 template <class T, class... Args>
 T* Pool::allocate(Args&&... args) {
     // The block pools only guarantee alignof(std::max_align_t); types with
-    // stricter alignment go to (aligned) operator new, which honors any
-    // alignment in C++17.
-    if constexpr (alignof(T) > alignof(std::max_align_t)) {
-        return new T(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size) {
+    // stricter alignment fall through to (aligned) operator new, which
+    // honors any alignment in C++17.
+    constexpr bool poolable = alignof(T) <= alignof(std::max_align_t);
+    if constexpr (poolable && sizeof(T) <= config::cache_line_size) {
         return small_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 2UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 2UL) {
         return medium_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 4UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 4UL) {
         return large_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 8UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 8UL) {
         return xlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 16UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 16UL) {
         return xxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 32UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 32UL) {
         return xxxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 64UL)  {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 64UL)  {
         return xxxxlarge_pool.template allocate<T,Args...>(std::forward<Args>(args)...);
     } else {
         return new T(std::forward<Args>(args)...);
@@ -57,21 +56,20 @@ T* Pool::allocate(Args&&... args) {
 
 template <class T>
 void Pool::deallocate(T* ptr) {
-    if constexpr (alignof(T) > alignof(std::max_align_t)) {
-        delete ptr;
-    } else if constexpr (sizeof(T) <= config::cache_line_size) {
+    constexpr bool poolable = alignof(T) <= alignof(std::max_align_t);
+    if constexpr (poolable && sizeof(T) <= config::cache_line_size) {
         return small_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 2UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 2UL) {
         return medium_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 4UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 4UL) {
         return large_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 8UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 8UL) {
         return xlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 16UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 16UL) {
         return xxlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 32UL) {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 32UL) {
         return xxxlarge_pool.template deallocate<T>(ptr);
-    } else if constexpr (sizeof(T) <= config::cache_line_size * 64UL)  {
+    } else if constexpr (poolable && sizeof(T) <= config::cache_line_size * 64UL)  {
         return xxxxlarge_pool.template deallocate<T>(ptr);
     } else {
         delete ptr;

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -451,15 +451,26 @@ bool FiberImpl<T,E>::evaluateOp(const std::shared_ptr<Scheduler>& sched) {
     switch(op->opType) {
     case VALUE:
     {
-        const FiberOp::ConstantData* data = op->data.constantData;
-        value.setValue(*data);
+        FiberOp::ConstantData* data = op->data.constantData;
+        if(op->unique()) {
+            // This fiber holds the only reference to the op and is about
+            // to drop it - move the value out instead of copying. Ops
+            // still shared (e.g. held by a re-runnable Task) are copied.
+            value.setValue(std::move(*data));
+        } else {
+            value.setValue(*data);
+        }
         op = nullptr;
     }
     break;
     case ERROR:
     {
-        const FiberOp::ConstantData* data = op->data.constantData;
-        value.setError(*data);
+        FiberOp::ConstantData* data = op->data.constantData;
+        if(op->unique()) {
+            value.setError(std::move(*data));
+        } else {
+            value.setError(*data);
+        }
         op = nullptr;
     }
     break;
@@ -506,11 +517,14 @@ bool FiberImpl<T,E>::evaluateOp(const std::shared_ptr<Scheduler>& sched) {
             auto deferred = (*data)(sched);
 
             if (auto result_opt = deferred->get()) {
+                // The optional (and the Either inside it) is a local copy
+                // owned by this frame - move the result out rather than
+                // copying it a second time.
                 if(result_opt->is_left()) {
-                    value.setValue(result_opt->get_left());
+                    value.setValue(std::move(*result_opt).get_left());
                     op = nullptr;
                 } else {
-                    value.setError(result_opt->get_right());
+                    value.setError(std::move(*result_opt).get_right());
                     op = nullptr;
                 }
             } else {

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -219,6 +219,19 @@ public:
     }
 
     /**
+     * Check whether this op is uniquely referenced (refcount of exactly 1).
+     * When the caller holds that single reference no other owner can
+     * observe the op, so it may safely move payload data out of the op
+     * rather than copying - the classic uniqueness optimization for
+     * otherwise-immutable structures. Freshly built per-iteration ops
+     * (e.g. the result of a flatMap continuation) are unique; ops still
+     * referenced by a `Task` are not and must be copied from.
+     */
+    bool unique() const noexcept {
+        return refcount.load(std::memory_order_acquire) == 1;
+    }
+
+    /**
      * Increment this op's intrusive reference count. Normally called only
      * by `FiberOpRef`.
      */

--- a/test/cask/TestErased.cpp
+++ b/test/cask/TestErased.cpp
@@ -136,3 +136,308 @@ TEST(Erased, RvalueAssignment) {
     EXPECT_TRUE(foo.has_value());
     EXPECT_EQ(foo.get<std::string>(), "hello");
 }
+
+// --- Storage-strategy nuances of the small-buffer / tagged-pointer design ---
+
+namespace {
+
+struct Counters {
+    int ctor = 0;
+    int copy_ctor = 0;
+    int move_ctor = 0;
+    int copy_assign = 0;
+    int move_assign = 0;
+    int dtor = 0;
+
+    int live() const { return ctor + copy_ctor + move_ctor - dtor; }
+};
+
+// Small non-trivial type: stored inline, managed through the per-type
+// operations table.
+struct Tracked {
+    Counters* counters;
+    int payload;
+
+    Tracked(Counters* counters, int payload) : counters(counters), payload(payload) { counters->ctor++; }
+    Tracked(const Tracked& other) : counters(other.counters), payload(other.payload) { counters->copy_ctor++; }
+    Tracked(Tracked&& other) noexcept : counters(other.counters), payload(other.payload) { counters->move_ctor++; }
+    Tracked& operator=(const Tracked& other) {
+        counters = other.counters;
+        payload = other.payload;
+        counters->copy_assign++;
+        return *this;
+    }
+    Tracked& operator=(Tracked&& other) noexcept {
+        counters = other.counters;
+        payload = other.payload;
+        counters->move_assign++;
+        return *this;
+    }
+    ~Tracked() { counters->dtor++; }
+};
+
+// Same semantics but padded past the inline buffer: pool-allocated.
+struct BigTracked : Tracked {
+    using Tracked::Tracked;
+    unsigned char pad[cask::erased::sbo_size] = {};
+};
+
+// Trivially-copyable type larger than the primitives the existing tests
+// use: stored inline with no operations table at all.
+struct TrivialBlob {
+    unsigned char bytes[16];
+};
+
+// Trivially-copyable but over-aligned past the buffer's pointer
+// alignment: must fall back to the pool.
+struct alignas(cask::erased::sbo_align * 4) OverAligned {
+    double value;
+};
+
+// Small, but its move constructor is not noexcept: must fall back to the
+// pool (Erased's noexcept move operations cannot risk a throwing
+// relocation).
+struct ThrowingMove {
+    int payload;
+
+    explicit ThrowingMove(int payload) : payload(payload) {}
+    ThrowingMove(const ThrowingMove&) = default;
+    ThrowingMove(ThrowingMove&& other) : payload(other.payload) {} // NOLINT(performance-noexcept-move-constructor)
+    ThrowingMove& operator=(const ThrowingMove&) = default;
+    ThrowingMove& operator=(ThrowingMove&& other) { // NOLINT(performance-noexcept-move-constructor)
+        payload = other.payload;
+        return *this;
+    }
+    ~ThrowingMove() = default;
+};
+
+// Sanity-check that the test types exercise the storage strategies they
+// are designed to exercise.
+static_assert(cask::erased::fits_sbo<Tracked>, "Tracked must be stored inline");
+static_assert(!cask::erased::trivial_sbo<Tracked>, "Tracked must use the operations table");
+static_assert(cask::erased::trivial_sbo<TrivialBlob>, "TrivialBlob must be trivially stored inline");
+static_assert(!cask::erased::fits_sbo<BigTracked>, "BigTracked must be pool-allocated");
+static_assert(!cask::erased::fits_sbo<OverAligned>, "OverAligned must be pool-allocated");
+static_assert(!cask::erased::fits_sbo<ThrowingMove>, "ThrowingMove must be pool-allocated");
+
+} // namespace
+
+TEST(Erased, InlineNonTrivialDestroyedExactlyOnce) {
+    Counters counters;
+
+    {
+        Erased foo((Tracked(&counters, 7)));
+        EXPECT_EQ(foo.get<Tracked>().payload, 7);
+        EXPECT_EQ(counters.live(), 1);
+    }
+
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, InlineNonTrivialMoveEmptiesSourceAndBalancesLifetimes) {
+    Counters counters;
+
+    {
+        Erased first((Tracked(&counters, 7)));
+        Erased second(std::move(first));
+
+        // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+        EXPECT_FALSE(first.has_value());
+        EXPECT_TRUE(second.has_value());
+        EXPECT_EQ(second.get<Tracked>().payload, 7);
+
+        // Inline moves relocate the value: exactly one live instance, and
+        // the moved-from Erased must not destroy it again.
+        EXPECT_EQ(counters.live(), 1);
+    }
+
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, InlineNonTrivialCopyIsIndependent) {
+    Counters counters;
+
+    Erased first((Tracked(&counters, 7)));
+    Erased second(first);
+
+    first.reset();
+
+    EXPECT_FALSE(first.has_value());
+    EXPECT_TRUE(second.has_value());
+    EXPECT_EQ(second.get<Tracked>().payload, 7);
+    EXPECT_EQ(counters.live(), 1);
+
+    second.reset();
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, SameTypeAssignmentReusesStorage) {
+    Counters counters;
+
+    Erased foo((Tracked(&counters, 1)));
+    int dtors_before = counters.dtor;
+
+    foo = Tracked(&counters, 2);
+
+    // Assigning the same type must hit the in-place fast path: the held
+    // value is assigned to, not destroyed and reconstructed.
+    EXPECT_EQ(counters.move_assign, 1);
+    EXPECT_EQ(counters.dtor, dtors_before + 1); // only the temporary
+    EXPECT_EQ(foo.get<Tracked>().payload, 2);
+}
+
+TEST(Erased, DifferentTypeAssignmentDestroysOldValue) {
+    Counters counters;
+
+    Erased foo((Tracked(&counters, 1)));
+    foo = std::string("hello");
+
+    EXPECT_EQ(counters.live(), 0);
+    EXPECT_EQ(foo.get<std::string>(), "hello");
+}
+
+TEST(Erased, TrivialValuesRoundTrip) {
+    TrivialBlob blob;
+    for(std::size_t i = 0; i < sizeof(blob.bytes); i++) {
+        blob.bytes[i] = static_cast<unsigned char>(i * 3);
+    }
+
+    Erased foo(blob);
+    Erased copy(foo);
+    Erased moved(std::move(foo));
+
+    for(std::size_t i = 0; i < sizeof(blob.bytes); i++) {
+        EXPECT_EQ(copy.get<TrivialBlob>().bytes[i], blob.bytes[i]);
+        EXPECT_EQ(moved.get<TrivialBlob>().bytes[i], blob.bytes[i]);
+    }
+}
+
+TEST(Erased, TrivialTypesShareStateAcrossAssignment) {
+    // Trivial inline types of the same size share the same (tableless)
+    // state, so assigning one over another reuses the buffer - safely,
+    // since the fast path copies raw bytes rather than invoking the
+    // type's assignment operator. Differently-sized trivial types have
+    // distinct states and take the reset-and-reconstruct path.
+    Erased foo(123);
+
+    foo = 4.5f; // same size as int: in-place byte copy
+    EXPECT_EQ(foo.get<float>(), 4.5f);
+
+    foo = 3.5; // different size: reset + construct
+    EXPECT_EQ(foo.get<double>(), 3.5);
+
+    foo = 456;
+    EXPECT_EQ(foo.get<int>(), 456);
+}
+
+TEST(Erased, PooledValueDestroyedExactlyOnce) {
+    Counters counters;
+
+    {
+        Erased foo((BigTracked(&counters, 7)));
+        EXPECT_EQ(foo.get<BigTracked>().payload, 7);
+        EXPECT_EQ(counters.live(), 1);
+    }
+
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, PooledMoveStealsPointerWithoutTouchingValue) {
+    Counters counters;
+
+    Erased first((BigTracked(&counters, 7)));
+    int move_ctors_before = counters.move_ctor;
+    int dtors_before = counters.dtor;
+
+    Erased second(std::move(first));
+
+    // A pooled move transfers ownership of the allocation: the held value
+    // itself must not be moved or destroyed.
+    EXPECT_EQ(counters.move_ctor, move_ctors_before);
+    EXPECT_EQ(counters.dtor, dtors_before);
+
+    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    EXPECT_FALSE(first.has_value());
+    EXPECT_EQ(second.get<BigTracked>().payload, 7);
+
+    second.reset();
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, PooledCopyIsIndependent) {
+    Counters counters;
+
+    Erased first((BigTracked(&counters, 7)));
+    Erased second(first);
+
+    first.reset();
+
+    EXPECT_TRUE(second.has_value());
+    EXPECT_EQ(second.get<BigTracked>().payload, 7);
+    EXPECT_EQ(counters.live(), 1);
+
+    second.reset();
+    EXPECT_EQ(counters.live(), 0);
+}
+
+TEST(Erased, OverAlignedValueRoundTrips) {
+    Erased foo(OverAligned{3.5});
+    Erased copy(foo);
+    Erased moved(std::move(foo));
+
+    EXPECT_EQ(copy.get<OverAligned>().value, 3.5);
+    EXPECT_EQ(moved.get<OverAligned>().value, 3.5);
+}
+
+TEST(Erased, ThrowingMoveValueRoundTrips) {
+    Erased foo(ThrowingMove{7});
+    Erased copy(foo);
+    Erased moved(std::move(foo));
+
+    EXPECT_EQ(copy.get<ThrowingMove>().payload, 7);
+    EXPECT_EQ(moved.get<ThrowingMove>().payload, 7);
+}
+
+TEST(Erased, SharedPtrRefcountsAcrossCopyAndMove) {
+    auto ptr = std::make_shared<int>(42);
+
+    Erased foo(ptr);
+    EXPECT_EQ(ptr.use_count(), 2);
+
+    Erased copy(foo);
+    EXPECT_EQ(ptr.use_count(), 3);
+
+    Erased moved(std::move(foo));
+    EXPECT_EQ(ptr.use_count(), 3);
+
+    copy.reset();
+    moved.reset();
+    EXPECT_EQ(ptr.use_count(), 1);
+    EXPECT_EQ(*ptr, 42);
+}
+
+TEST(Erased, MovedFromIsReusable) {
+    Erased first(std::string("hello"));
+    Erased second(std::move(first));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is reusable
+    first = std::string("world");
+
+    EXPECT_EQ(first.get<std::string>(), "world");
+    EXPECT_EQ(second.get<std::string>(), "hello");
+}
+
+TEST(Erased, SelfAssignmentIsSafe) {
+    Counters counters;
+
+    Erased foo((Tracked(&counters, 7)));
+    Erased& alias = foo;
+    foo = alias;
+
+    EXPECT_TRUE(foo.has_value());
+    EXPECT_EQ(foo.get<Tracked>().payload, 7);
+    EXPECT_EQ(counters.live(), 1);
+
+    foo.reset();
+    EXPECT_EQ(counters.live(), 0);
+}

--- a/test/cask/TestErased.cpp
+++ b/test/cask/TestErased.cpp
@@ -85,7 +85,7 @@ TEST(Erased, MoveConstructor) {
     Erased first(123);
     Erased second(std::move(first));
 
-    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
     EXPECT_FALSE(first.has_value());
     EXPECT_TRUE(second.has_value());
     EXPECT_EQ(second.get<int>(), 123);
@@ -96,7 +96,7 @@ TEST(Erased, MoveAssignment) {
     Erased second;
     second = std::move(first);
 
-    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
     EXPECT_FALSE(first.has_value());
     EXPECT_TRUE(second.has_value());
     EXPECT_EQ(second.get<int>(), 123);
@@ -107,7 +107,7 @@ TEST(Erased, MoveAssignmentOverwrites) {
     Erased second(std::string("hello"));
     second = std::move(first);
 
-    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
     EXPECT_FALSE(first.has_value());
     EXPECT_TRUE(second.has_value());
     EXPECT_EQ(second.get<int>(), 123);
@@ -118,7 +118,7 @@ TEST(Erased, MoveConstructorWithString) {
     Erased first(original);
     Erased second(std::move(first));
 
-    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
     EXPECT_FALSE(first.has_value());
     EXPECT_TRUE(second.has_value());
     EXPECT_EQ(second.get<std::string>(), "hello world");
@@ -162,9 +162,11 @@ struct Tracked {
     Tracked(const Tracked& other) : counters(other.counters), payload(other.payload) { counters->copy_ctor++; }
     Tracked(Tracked&& other) noexcept : counters(other.counters), payload(other.payload) { counters->move_ctor++; }
     Tracked& operator=(const Tracked& other) {
-        counters = other.counters;
-        payload = other.payload;
-        counters->copy_assign++;
+        if(this != &other) {
+            counters = other.counters;
+            payload = other.payload;
+            counters->copy_assign++;
+        }
         return *this;
     }
     Tracked& operator=(Tracked&& other) noexcept {
@@ -241,7 +243,7 @@ TEST(Erased, InlineNonTrivialMoveEmptiesSourceAndBalancesLifetimes) {
         Erased first((Tracked(&counters, 7)));
         Erased second(std::move(first));
 
-        // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+        // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
         EXPECT_FALSE(first.has_value());
         EXPECT_TRUE(second.has_value());
         EXPECT_EQ(second.get<Tracked>().payload, 7);
@@ -356,7 +358,7 @@ TEST(Erased, PooledMoveStealsPointerWithoutTouchingValue) {
     EXPECT_EQ(counters.move_ctor, move_ctors_before);
     EXPECT_EQ(counters.dtor, dtors_before);
 
-    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Testing that moved-from state is empty
     EXPECT_FALSE(first.has_value());
     EXPECT_EQ(second.get<BigTracked>().payload, 7);
 

--- a/test/cask/TestFiber.cpp
+++ b/test/cask/TestFiber.cpp
@@ -82,6 +82,53 @@ TEST(TestFiber, EvaluatesPureValueSync) {
     ASSERT_EQ(result->get_left(), 123);
 }
 
+TEST(TestFiber, SharedOpEvaluatedRepeatedlyKeepsConstant) {
+    // A VALUE op that is still referenced externally (here, by this test -
+    // exactly like an op graph held by a re-runnable Task) must have its
+    // constant copied out during evaluation, not moved out: every
+    // evaluation must observe the original value. A non-trivial type is
+    // used so a wrongly-moved-out value is observable.
+    auto op = FiberOp::value(std::string("hello"));
+
+    for(int i = 0; i < 3; i++) {
+        auto result = Fiber<std::string,std::string>::runSync(op);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result->is_left());
+        ASSERT_EQ(result->get_left(), "hello");
+    }
+}
+
+TEST(TestFiber, SharedErrorOpEvaluatedRepeatedlyKeepsConstant) {
+    auto op = FiberOp::error(std::string("broke"));
+
+    for(int i = 0; i < 3; i++) {
+        auto result = Fiber<std::string,std::string>::runSync(op);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result->is_right());
+        ASSERT_EQ(result->get_right(), "broke");
+    }
+}
+
+TEST(TestFiber, SharedFlatMapChainEvaluatedRepeatedlyKeepsConstants) {
+    // The flatMap continuation returns a freshly-built (uniquely
+    // referenced) op each evaluation - its constant may be moved out - but
+    // the shared input op's constant must survive every run.
+    auto op = FiberOp::value(std::string("hello"))->flatMap([](auto value) {
+        auto str = value.underlying().template get<std::string>();
+        return FiberOp::value(str + " world");
+    });
+
+    for(int i = 0; i < 3; i++) {
+        auto result = Fiber<std::string,std::string>::runSync(op);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result->is_left());
+        ASSERT_EQ(result->get_left(), "hello world");
+    }
+}
+
 TEST(TestFiber, EvaluatesPureError) {
     auto sched = std::make_shared<BenchScheduler>();
     auto op = FiberOp::error(std::string("broke"));

--- a/test/cask/fiber/TestFiberValue.cpp
+++ b/test/cask/fiber/TestFiberValue.cpp
@@ -82,4 +82,60 @@ TEST(FiberValue, ErasedMoveCancel) {
     EXPECT_TRUE(value.isCanceled());
 }
 
+TEST(FiberValue, SetValueMoveLeavesSourceEmpty) {
+    Erased erased(std::string("hello"));
+    FiberValue value;
+
+    value.setValue(std::move(erased));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    EXPECT_FALSE(erased.has_value());
+    EXPECT_TRUE(value.isValue());
+    EXPECT_EQ(value.getValue()->template get<std::string>(), "hello");
+}
+
+TEST(FiberValue, SetErrorMoveLeavesSourceEmpty) {
+    Erased erased(std::string("boom"));
+    FiberValue value;
+
+    value.setError(std::move(erased));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move): Testing that moved-from state is empty
+    EXPECT_FALSE(erased.has_value());
+    EXPECT_TRUE(value.isError());
+    EXPECT_EQ(value.getError()->template get<std::string>(), "boom");
+}
+
+TEST(FiberValue, SetValueCopyLeavesSourceIntact) {
+    Erased erased(std::string("hello"));
+    FiberValue value;
+
+    value.setValue(erased);
+
+    EXPECT_TRUE(erased.has_value());
+    EXPECT_EQ(erased.get<std::string>(), "hello");
+    EXPECT_EQ(value.getValue()->template get<std::string>(), "hello");
+}
+
+TEST(FiberValue, SetValueMoveOverwritesPreviousValue) {
+    FiberValue value(Erased(std::string("first")), false, false);
+
+    value.setValue(Erased(std::string("second")));
+
+    EXPECT_TRUE(value.isValue());
+    EXPECT_EQ(value.getValue()->template get<std::string>(), "second");
+}
+
+TEST(FiberValue, GetValueReturnsIndependentCopy) {
+    FiberValue value(Erased(std::string("hello")), false, false);
+
+    auto copy = value.getValue();
+    copy->template get<std::string>() += " world";
+
+    // The accessor hands out a copy - mutating it must not affect the
+    // value still held by the fiber.
+    EXPECT_EQ(copy->template get<std::string>(), "hello world");
+    EXPECT_EQ(value.underlying().template get<std::string>(), "hello");
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access)


### PR DESCRIPTION
This change implements a pair of complimentary changes which greatly increase the performance of cask pipelines by optimizing how they move around type erased values.

The first optimization is to `Erased` itself. The optimization is to avoid pool allocations for small values. For small values the memory is just allocated as part of `Erased` and there is no need for a second pool allocation for it. For large values, we retain the previous approach which forces pool allocation. To maximize the size of values we can hold without resorting to pool allocation tagged pointers are used as both the pointer to storage and the state flag needed to disambiguate between local and pooled storage. Finally, an optimization here was made so that the operations for a given type aren't re-allocated constantly and instead are derived at compile time using template magic.

The second optimization focuses on making `FiberValue` able to move values in more situations. Specifically, the optimization is to detect when a move is safe by using the intrusive refcount it already holds. When this refcount is 1, when can properly infer that a move is safe because the existing reference is the only reference to the internal data.

Together, these changes improve performance significantly in benchmarks. Benchmarks of long flatmap chains show increases of throughput in the 20% to 40% range depending on the kind of value being forwarded through the pipeline. For applications, this kind of result will lead to a drastic reduction in the overhead associated with using cask.