### PR TITLE
fix: allow release workflow to work if VERSION file not updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,11 @@ jobs:
     - name: Commit VERSION file
       run: |
         git add VERSION
-        git commit -m "ci: release of version ${{ steps.version.outputs.tag_version }} [skip ci]"
+        if git diff --cached --quiet; then
+          echo "VERSION file already up to date; nothing to commit"
+        else
+          git commit -m "ci: release of version ${{ steps.version.outputs.tag_version }} [skip ci]"
+        fi
     
     - name: Create Git tag
       run: |


### PR DESCRIPTION
The release flow is currently breaking because #118 updated the version number and CHANGELOG in one go - which makes sense when major or minor reving. This change just allows the release workflow to continue in the case where the version number doesn't need to be updated in source control.