### PR TITLE
perf: move payloads through Task operators

### DIFF
--- a/bench/BenchTaskOperators.cpp
+++ b/bench/BenchTaskOperators.cpp
@@ -1,0 +1,233 @@
+//          Copyright Tango Tango, Inc. 2020 - 2021.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include <benchmark/benchmark.h>
+#include <string>
+#include <vector>
+#include "cask/Task.hpp"
+
+using cask::Either;
+using cask::None;
+using cask::Task;
+
+// Benchmarks for per-operator payload traffic. Each stage of a task
+// composition hands its value/error payload to the next stage through
+// FiberValue/Erased - these benchmarks use copy-expensive, move-cheap
+// payloads (vectors/strings) so that a payload copy at any stage shows
+// up directly in the measured time.
+
+namespace {
+
+constexpr std::size_t payload_elems = 512;
+
+std::vector<int> make_payload() {
+    return std::vector<int>(payload_elems, 42);
+}
+
+using VectorTask = Task<std::vector<int>, std::vector<int>>;
+
+} // namespace
+
+// A chain of map stages moving a vector payload through each stage.
+static void BM_Map_VectorChain(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template map<std::vector<int>>([](std::vector<int>&& value) {
+            value[0]++;
+            return std::move(value);
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_Map_VectorChain)->Range(1, 256);
+
+// A success payload passing untouched through a chain of error-side
+// operators (mapError) - exercises the value passthrough branch.
+static void BM_MapError_ValuePassthrough(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template mapError<std::vector<int>>([](std::vector<int>&& error) {
+            return std::move(error);
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_MapError_ValuePassthrough)->Range(1, 256);
+
+// An error payload flowing through a chain of mapError stages.
+static void BM_MapError_ErrorChain(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::raiseError(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template mapError<std::vector<int>>([](std::vector<int>&& error) {
+            error[0]++;
+            return std::move(error);
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_MapError_ErrorChain)->Range(1, 256);
+
+// A success payload passing untouched through a chain of flatMapError stages.
+static void BM_FlatMapError_ValuePassthrough(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template flatMapError<std::vector<int>>([](std::vector<int>&& error) {
+            return VectorTask::raiseError(std::move(error));
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_FlatMapError_ValuePassthrough)->Range(1, 256);
+
+// A vector payload moved through a chain of flatMap stages.
+static void BM_FlatMap_VectorChain(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template flatMap<std::vector<int>>([](std::vector<int>&& value) {
+            value[0]++;
+            return VectorTask::pure(std::move(value));
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_FlatMap_VectorChain)->Range(1, 256);
+
+// Repeated materialize/dematerialize round trips - each round trip wraps
+// the payload into an Either and unwraps it again.
+static void BM_MaterializeDematerialize_Roundtrip(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.materialize().template dematerialize<std::vector<int>>();
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_MaterializeDematerialize_Roundtrip)->Range(1, 128);
+
+// Repeated failed() transpositions - each pair of stages moves the payload
+// from the value channel to the error channel and back.
+static void BM_Failed_Roundtrip(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.failed().failed();
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_Failed_Roundtrip)->Range(1, 128);
+
+// An error payload consumed by a recover stage after passing through a
+// chain of onError side-effect stages (which only observe the error).
+static void BM_OnError_ErrorChain(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::raiseError(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.onError([](const std::vector<int>& error) {
+            benchmark::DoNotOptimize(error.data());
+        });
+    }
+    task = task.recover([](std::vector<int>&& error) {
+        return std::move(error);
+    });
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_OnError_ErrorChain)->Range(1, 256);
+
+// A success payload passing through a chain of guarantee finalizers.
+static void BM_Guarantee_ValuePassthrough(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.guarantee(Task<None, std::vector<int>>::none());
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_Guarantee_ValuePassthrough)->Range(1, 128);
+
+// A success payload passing through a chain of doOnCancel stages.
+static void BM_DoOnCancel_ValuePassthrough(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    VectorTask task = VectorTask::pure(make_payload());
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.doOnCancel(Task<None, None>::none());
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_DoOnCancel_ValuePassthrough)->Range(1, 128);
+
+// String payloads through map - a smaller but heap-backed payload that is
+// common in practice.
+static void BM_Map_StringChain(benchmark::State& state) {
+    const int chain_length = static_cast<int>(state.range(0));
+
+    Task<std::string> task = Task<std::string>::pure(std::string(256, 'x'));
+    for (int i = 0; i < chain_length; ++i) {
+        task = task.template map<std::string>([](std::string&& value) {
+            value[0] = 'y';
+            return std::move(value);
+        });
+    }
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_Map_StringChain)->Range(1, 256);

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -7,6 +7,7 @@ if get_option('build_benchmarks')
         'BenchFlatMap.cpp',
         'BenchPool.cpp',
         'BenchSchedulerFlatMap.cpp',
+        'BenchTaskOperators.cpp',
         'main.cpp'
     ]
 

--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -258,12 +258,12 @@ public:
             op->flatMap([predicate = std::forward<Predicate>(predicate)](auto&& fiber_value) {
                 try {
                     if(fiber_value.isValue()) {
-                        auto input = fiber_value.underlying().template get<T>();
+                        auto input = std::move(fiber_value.underlying().template get<T>());
                         auto result = predicate(std::forward<T>(input));
                         auto erased = Erased(std::forward<T2>(result));
                         return fiber::FiberOp::value(std::move(erased));
                     } else if(fiber_value.isError()) {
-                        return fiber::FiberOp::error(fiber_value.underlying());
+                        return fiber::FiberOp::error(std::move(fiber_value.underlying()));
                     } else {
                         return fiber::FiberOp::cancel();
                     }
@@ -291,9 +291,9 @@ public:
             op->flatMap([predicate = std::forward<Predicate>(predicate)](auto&& fiber_value) {
                 try {
                     if(fiber_value.isValue()) {
-                        return fiber::FiberOp::value(fiber_value.underlying());
+                        return fiber::FiberOp::value(std::move(fiber_value.underlying()));
                     } else if(fiber_value.isError()) {
-                        auto input = fiber_value.underlying().template get<E>();
+                        auto input = std::move(fiber_value.underlying().template get<E>());
                         auto result = predicate(std::forward<E>(input));
                         auto erased = Erased(std::forward<E2>(result));
                         return fiber::FiberOp::error(std::move(erased));
@@ -330,11 +330,11 @@ public:
             op->flatMap([predicate = std::forward<Predicate>(predicate)](auto&& fiber_input) {
                 try {
                     if(fiber_input.isValue()) {
-                        auto input = fiber_input.underlying().template get<T>();
+                        auto input = std::move(fiber_input.underlying().template get<T>());
                         auto resultTask = predicate(std::forward<T>(input));
                         return resultTask.op;
                     } else if(fiber_input.isError()) {
-                        return fiber::FiberOp::error(fiber_input.underlying());
+                        return fiber::FiberOp::error(std::move(fiber_input.underlying()));
                     } else {
                         return fiber::FiberOp::cancel();
                     }
@@ -366,9 +366,9 @@ public:
         return Task<T,E2>(
             op->flatMap([predicate = std::forward<Predicate>(predicate)](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
-                    return fiber::FiberOp::value(fiber_input.underlying());
+                    return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {
-                    auto input = fiber_input.underlying().template get<E>();
+                    auto input = std::move(fiber_input.underlying().template get<E>());
                     auto resultTask = predicate(std::forward<E>(input));
                     return resultTask.op;
                 } else {
@@ -408,11 +408,11 @@ public:
                 op->flatMap([successPredicate, errorPredicate](auto&& fiber_input) {
                     try {
                         if(fiber_input.isValue()) {
-                            auto input = fiber_input.underlying().template get<T>();
+                            auto input = std::move(fiber_input.underlying().template get<T>());
                             auto resultTask = successPredicate(std::forward<T>(input));
                             return resultTask.op;
                         } else if(fiber_input.isError()) {
-                            auto input = fiber_input.underlying().template get<E>();
+                            auto input = std::move(fiber_input.underlying().template get<E>());
                             auto resultTask = errorPredicate(std::forward<E>(input));
                             return resultTask.op;
                         } else {
@@ -429,11 +429,11 @@ public:
                 op->flatMap([successPredicate, errorPredicate](auto&& fiber_input) {
                     try {
                         if(fiber_input.isValue()) {
-                            auto input = fiber_input.underlying().template get<T>();
+                            auto input = std::move(fiber_input.underlying().template get<T>());
                             auto resultTask = successPredicate(std::forward<T>(input));
                             return resultTask.op;
                         } else if(fiber_input.isError()) {
-                            auto input = fiber_input.underlying().template get<E>();
+                            auto input = std::move(fiber_input.underlying().template get<E>());
                             auto resultTask = errorPredicate(std::forward<E>(input));
                             return resultTask.op;
                         } else {
@@ -461,11 +461,11 @@ public:
         return Task<E,T>(
             op->flatMap([](auto&& input) {
                 if(input.isError()) {
-                    auto error = input.underlying().template get<E>();
+                    auto error = std::move(input.underlying().template get<E>());
                     auto erased = Erased(std::forward<E>(error));
                     return fiber::FiberOp::value(std::move(erased));
                 } else if(input.isValue()) {
-                    auto value = input.underlying().template get<T>();
+                    auto value = std::move(input.underlying().template get<T>());
                     auto erased = Erased(std::forward<T>(value));
                     return fiber::FiberOp::error(std::move(erased));
                 } else {
@@ -491,11 +491,11 @@ public:
             op->flatMap([handler = std::forward<Predicate>(handler)](auto&& fiber_input) {
                 try {
                     if(fiber_input.isValue()) {
-                        return fiber::FiberOp::value(fiber_input.underlying());
+                        return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                     } else if(fiber_input.isError()) {
-                        auto error = fiber_input.underlying().template get<E>();
+                        const E& error = fiber_input.underlying().template get<E>();
                         handler(error);
-                        return fiber::FiberOp::error(fiber_input.underlying());
+                        return fiber::FiberOp::error(std::move(fiber_input.underlying()));
                     } else {
                         return fiber::FiberOp::cancel();
                     }
@@ -521,9 +521,9 @@ public:
         return Task<T,E>(
             op->flatMap([handler = std::forward<Task<None,None>>(handler)](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
-                    return fiber::FiberOp::value(fiber_input.underlying());
+                    return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {
-                    return fiber::FiberOp::error(fiber_input.underlying());
+                    return fiber::FiberOp::error(std::move(fiber_input.underlying()));
                 } else {
                     return handler.op->flatMap([](auto) {
                         return fiber::FiberOp::cancel();
@@ -548,9 +548,9 @@ public:
         return Task<T,E>(
             op->flatMap([error = std::forward<E>(error)](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
-                    return fiber::FiberOp::value(fiber_input.underlying());
+                    return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {
-                    return fiber::FiberOp::error(fiber_input.underlying());
+                    return fiber::FiberOp::error(std::move(fiber_input.underlying()));
                 } else {
                     return fiber::FiberOp::error(error);
                 }
@@ -569,12 +569,12 @@ public:
         return Task<Either<T,E>,E>(
             op->flatMap([](auto&& fiber_value) {
                 if(fiber_value.isValue()) {
-                    auto value = fiber_value.underlying().template get<T>();
+                    auto value = std::move(fiber_value.underlying().template get<T>());
                     auto either = Either<T,E>::left(std::forward<T>(value));
                     auto erased = Erased(std::move(either));
                     return fiber::FiberOp::value(std::move(erased));
                 } else if(fiber_value.isError()) {
-                    auto error = fiber_value.underlying().template get<E>();
+                    auto error = std::move(fiber_value.underlying().template get<E>());
                     auto either = Either<T,E>::right(std::forward<E>(error));
                     auto erased = Erased(std::move(either));
                     return fiber::FiberOp::value(std::move(erased));
@@ -609,18 +609,18 @@ public:
         return Task<T2,E>(
             op->flatMap([](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
-                    auto either = fiber_input.underlying().template get<Either<T2,E>>();
+                    auto either = std::move(fiber_input.underlying().template get<Either<T2,E>>());
                     if(either.is_left()) {
-                        auto value = either.get_left();
+                        auto value = std::move(either).get_left();
                         auto erased = Erased(std::forward<T2>(value));
-                        return fiber::FiberOp::value(erased);
+                        return fiber::FiberOp::value(std::move(erased));
                     } else {
-                        auto error = either.get_right();
+                        auto error = std::move(either).get_right();
                         auto erased = Erased(std::forward<E>(error));
-                        return fiber::FiberOp::error(erased);
+                        return fiber::FiberOp::error(std::move(erased));
                     }
                 } else if(fiber_input.isError()) {
-                    return fiber::FiberOp::error(fiber_input.underlying());
+                    return fiber::FiberOp::error(std::move(fiber_input.underlying()));
                 } else {
                     return fiber::FiberOp::cancel();
                 }
@@ -665,9 +665,9 @@ public:
         return Task<T,E>(
             op->flatMap([predicate = std::forward<Predicate>(predicate)](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
-                    return fiber::FiberOp::value(fiber_input.underlying());
+                    return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {
-                    auto error = fiber_input.underlying().template get<E>();
+                    auto error = std::move(fiber_input.underlying().template get<E>());
                     auto result = predicate(std::forward<E>(error));
                     auto erased = Erased(std::move(result));
                     return fiber::FiberOp::value(std::move(erased));
@@ -762,15 +762,15 @@ public:
         return Task<T,E>(
             op->flatMap(
                 [task = std::forward<Arg>(task)](auto&& fiber_value) {
-                    return task.op->flatMap([fiber_value = std::forward<fiber::FiberValue>(fiber_value)](auto&& guaranteed_value) {
+                    return task.op->flatMap([fiber_value = std::forward<fiber::FiberValue>(fiber_value)](auto&& guaranteed_value) mutable {
                         if(guaranteed_value.isError()) {
-                            return fiber::FiberOp::error(guaranteed_value.underlying());
+                            return fiber::FiberOp::error(std::move(guaranteed_value.underlying()));
                         } else if(guaranteed_value.isCanceled() || fiber_value.isCanceled()) {
                             return fiber::FiberOp::cancel();
                         } else if(fiber_value.isValue()) {
-                            return fiber::FiberOp::value(fiber_value.underlying());
+                            return fiber::FiberOp::value(std::move(fiber_value.underlying()));
                         } else {
-                            return fiber::FiberOp::error(fiber_value.underlying());
+                            return fiber::FiberOp::error(std::move(fiber_value.underlying()));
                         }
                     });
                 }

--- a/include/cask/fiber/FiberValue.hpp
+++ b/include/cask/fiber/FiberValue.hpp
@@ -32,6 +32,7 @@ public:
     std::optional<Erased> getValue() const;
     std::optional<Erased> getError() const;
     const Erased& underlying() const;
+    Erased& underlying();
 
 private:
     Erased value;

--- a/include/cask/observable/SwitchMapObserver.hpp
+++ b/include/cask/observable/SwitchMapObserver.hpp
@@ -97,7 +97,12 @@ Task<None,None> SwitchMapObserver<TI,TO,E>::onComplete() {
             subscription->onFiberShutdown([promise](auto) {
                 promise->success(None());
             });
-            return Task<None,None>::forPromise(promise);
+            // Capture the subscription so the fiber stays alive until it
+            // completes - scheduler timer callbacks only hold weak references.
+            return Task<None,None>::forPromise(promise)
+                .template map<None>([subscription](None&& value) {
+                    return std::move(value);
+                });
         } else {
             return Task<None,None>::none();
         }

--- a/include/cask/observable/SwitchMapObserver.hpp
+++ b/include/cask/observable/SwitchMapObserver.hpp
@@ -100,8 +100,8 @@ Task<None,None> SwitchMapObserver<TI,TO,E>::onComplete() {
             // Capture the subscription so the fiber stays alive until it
             // completes - scheduler timer callbacks only hold weak references.
             return Task<None,None>::forPromise(promise)
-                .template map<None>([subscription](None&& value) {
-                    return std::move(value);
+                .template map<None>([subscription](None&&) {
+                    return None();
                 });
         } else {
             return Task<None,None>::none();

--- a/src/cask/fiber/FiberValue.cpp
+++ b/src/cask/fiber/FiberValue.cpp
@@ -90,5 +90,9 @@ const Erased& FiberValue::underlying() const {
     return value;
 }
 
+Erased& FiberValue::underlying() {
+    return value;
+}
+
 
 } // namespace cask::fiber


### PR DESCRIPTION
Task operators previously copied the value/error out of the fiber's Erased payload at every composition stage because FiberValue only exposed a const underlying() accessor. This adds a non-const Erased& underlying() overload and updates all Task operators (map, flatMap, mapError, flatMapError, flatMapBoth, failed, onError, materialize, dematerialize, recover, guarantee, doOnCancel, onCancelRaiseError) to move payloads through each stage.

This also fixes a latent lifetime bug in SwitchMapObserver that the optimization exposed: onComplete registered an onFiberShutdown callback on the inner subscription fiber but dropped its only owning reference while awaiting the shutdown promise. The fiber previously survived only because a stale copy of the shared_ptr lingered in another fiber's value slot; since scheduler delay-timer callbacks hold only a weak_ptr to their fiber, moving the payload destroyed the fiber and its timer never fired, hanging the stream. The subscription is now captured in the op graph awaiting the promise.

Adds bench/BenchTaskOperators.cpp with 11 benchmarks exercising copy-expensive payloads through the affected operators.

Benchmark results (cpu time, before -> after):
- BM_OnError_ErrorChain/256: 62868 -> 27583 ns (-56%)
- BM_MaterializeDematerialize_Roundtrip/128: 72625 -> 33702 ns (-54%)
- BM_Map_VectorChain/256: 47420 -> 27392 ns (-42%)
- BM_MapError_ErrorChain/256: 48475 -> 28389 ns (-41%)
- BM_DoOnCancel_ValuePassthrough/128: 30879 -> 18488 ns (-40%)
- BM_Failed_Roundtrip/128: 46254 -> 27770 ns (-40%)
- BM_FlatMap_VectorChain/256: 48297 -> 30196 ns (-38%)
- BM_Guarantee_ValuePassthrough/128: 58242 -> 48269 ns (-17%)
- BM_Map_StringChain/256: 33927 -> 30506 ns (-10%)