### PR TITLE
fix: doOnCancel/onCancelRaiseError lvalue forwarding

### DIFF
--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -546,7 +546,7 @@ public:
     >>
     Task<T,E> onCancelRaiseError(Arg&& error) const noexcept  {
         return Task<T,E>(
-            op->flatMap([error = std::forward<E>(error)](auto&& fiber_input) {
+            op->flatMap([error = E(std::forward<Arg>(error))](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
                     return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {

--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -519,7 +519,7 @@ public:
     >>
     Task<T,E> doOnCancel(Arg&& handler) const noexcept  {
         return Task<T,E>(
-            op->flatMap([handler = std::forward<Task<None,None>>(handler)](auto&& fiber_input) {
+            op->flatMap([handler = std::forward<Arg>(handler)](auto&& fiber_input) {
                 if(fiber_input.isValue()) {
                     return fiber::FiberOp::value(std::move(fiber_input.underlying()));
                 } else if(fiber_input.isError()) {

--- a/test/cask/task/TestTaskDoOnCancel.cpp
+++ b/test/cask/task/TestTaskDoOnCancel.cpp
@@ -90,3 +90,26 @@ TEST(TaskDoOnCancel, RunsForCanceledTask) {
     EXPECT_EQ(cancel_counter, 1);
 }
 
+TEST(TaskDoOnCancel, PreservesLvalueHandler) {
+    int cancel_counter = 0;
+    auto sched = std::make_shared<BenchScheduler>();
+    auto handler = Task<None,None>::eval([&cancel_counter] {
+        cancel_counter++;
+        return None();
+    });
+
+    auto task = Task<int,std::string>::never().doOnCancel(handler);
+
+    ASSERT_NE(handler.op, nullptr);
+
+    auto fiber = task.run(sched);
+    auto handler_fiber = handler.run(sched);
+
+    sched->run_ready_tasks();
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    ASSERT_TRUE(fiber->isCanceled());
+    ASSERT_TRUE(handler_fiber->getValue().has_value());
+    EXPECT_EQ(cancel_counter, 2);
+}

--- a/test/cask/task/TestTaskOnCancelRaiseError.cpp
+++ b/test/cask/task/TestTaskOnCancelRaiseError.cpp
@@ -93,7 +93,8 @@ TEST(TaskOnCancelRaiseError,DoesNotMoveFromLvalueError) {
     fiber->cancel();
     sched->run_ready_tasks();
 
-    ASSERT_TRUE(fiber->getError().has_value());
-    EXPECT_EQ(fiber->getError()->message, "cancel happened");
+    auto fiber_error = fiber->getError();
+    ASSERT_TRUE(fiber_error.has_value());
+    EXPECT_EQ(fiber_error->message, "cancel happened");
     EXPECT_FALSE(error.moved_from);
 }

--- a/test/cask/task/TestTaskOnCancelRaiseError.cpp
+++ b/test/cask/task/TestTaskOnCancelRaiseError.cpp
@@ -95,6 +95,10 @@ TEST(TaskOnCancelRaiseError,DoesNotMoveFromLvalueError) {
 
     auto fiber_error = fiber->getError();
     ASSERT_TRUE(fiber_error.has_value());
+    if(!fiber_error.has_value()) {
+        return;
+    }
+
     EXPECT_EQ(fiber_error->message, "cancel happened");
     EXPECT_FALSE(error.moved_from);
 }

--- a/test/cask/task/TestTaskOnCancelRaiseError.cpp
+++ b/test/cask/task/TestTaskOnCancelRaiseError.cpp
@@ -10,6 +10,34 @@
 using cask::Task;
 using cask::scheduler::BenchScheduler;
 
+namespace {
+struct MoveTrackingError {
+    std::string message;
+    bool moved_from = false;
+
+    explicit MoveTrackingError(std::string message)
+        : message(std::move(message)) {}
+
+    MoveTrackingError(const MoveTrackingError&) = default;
+    MoveTrackingError& operator=(const MoveTrackingError&) = default;
+
+    MoveTrackingError(MoveTrackingError&& other) noexcept
+        : message(std::move(other.message)) {
+        other.moved_from = true;
+    }
+
+    MoveTrackingError& operator=(MoveTrackingError&& other) noexcept {
+        if(this != &other) {
+            message = std::move(other.message);
+            moved_from = other.moved_from;
+            other.moved_from = true;
+        }
+
+        return *this;
+    }
+};
+}  // namespace
+
 TEST(TaskOnCancelRaiseError,ConvertsToError) {
     auto sched = std::make_shared<BenchScheduler>();
     auto fiber = Task<int, std::string>::never()
@@ -49,4 +77,23 @@ TEST(TaskOnCancelRaiseError,IgnoresError) {
     sched->run_ready_tasks();
 
     EXPECT_EQ(fiber->await(), "broke");
+}
+
+TEST(TaskOnCancelRaiseError,DoesNotMoveFromLvalueError) {
+    auto sched = std::make_shared<BenchScheduler>();
+    MoveTrackingError error("cancel happened");
+
+    auto fiber = Task<int, MoveTrackingError>::never()
+        .onCancelRaiseError(error)
+        .run(sched);
+
+    EXPECT_FALSE(error.moved_from);
+
+    sched->run_ready_tasks();
+    fiber->cancel();
+    sched->run_ready_tasks();
+
+    ASSERT_TRUE(fiber->getError().has_value());
+    EXPECT_EQ(fiber->getError()->message, "cancel happened");
+    EXPECT_FALSE(error.moved_from);
 }

--- a/test/cask/task/TestTaskOnCancelRaiseError.cpp
+++ b/test/cask/task/TestTaskOnCancelRaiseError.cpp
@@ -95,10 +95,7 @@ TEST(TaskOnCancelRaiseError,DoesNotMoveFromLvalueError) {
 
     auto fiber_error = fiber->getError();
     ASSERT_TRUE(fiber_error.has_value());
-    if(!fiber_error.has_value()) {
-        return;
-    }
-
-    EXPECT_EQ(fiber_error->message, "cancel happened");
+    const auto raised_error = fiber_error.value_or(MoveTrackingError(""));
+    EXPECT_EQ(raised_error.message, "cancel happened");
     EXPECT_FALSE(error.moved_from);
 }


### PR DESCRIPTION
Capture doOnCancel handlers with std::forward<Arg>(handler) so lvalue Task<None, None> handlers are not moved from during composition. Add a regression test that fails with the old capture and proves the original handler remains usable after wiring it into doOnCancel.

The similiar fix has been applied to onCancelRaiseError