### PR TITLE
fix: convert excepts thrown by thunks into errors

### DIFF
--- a/bench/BenchTaskOperators.cpp
+++ b/bench/BenchTaskOperators.cpp
@@ -7,10 +7,12 @@
 #include <string>
 #include <vector>
 #include "cask/Task.hpp"
+#include "cask/scheduler/BenchScheduler.hpp"
 
 using cask::Either;
 using cask::None;
 using cask::Task;
+using cask::scheduler::BenchScheduler;
 
 // Benchmarks for per-operator payload traffic. Each stage of a task
 // composition hands its value/error payload to the next stage through
@@ -29,6 +31,53 @@ std::vector<int> make_payload() {
 using VectorTask = Task<std::vector<int>, std::vector<int>>;
 
 } // namespace
+
+// A single eval thunk on the non-throwing fast path - isolates the overhead
+// of entering the THUNK branch in the fiber loop.
+static void BM_Eval_RunSync(benchmark::State& state) {
+    Task<int, std::string> task = Task<int, std::string>::eval([]() {
+        return 42;
+    });
+
+    for (auto _ : state) {
+        auto result = task.runSync();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_Eval_RunSync);
+
+// Fast path for deferAction: the callback does not throw and returns an
+// already-completed Deferred. This exercises the new typed catch boundary.
+static void BM_DeferAction_Async(benchmark::State& state) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto task = Task<int, std::string>::deferAction([](const auto&) {
+        return cask::Deferred<int, std::string>::pure(42);
+    });
+
+    for (auto _ : state) {
+        auto fiber = task.run(sched);
+        sched->run_ready_tasks();
+        auto result = fiber->await();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_DeferAction_Async);
+
+// Fast path for deferFiber: the callback does not throw and returns a fiber.
+static void BM_DeferFiber_Async(benchmark::State& state) {
+    auto sched = std::make_shared<BenchScheduler>();
+    auto task = Task<int, std::string>::deferFiber([](const auto& sched) {
+        return Task<int, std::string>::pure(42).run(sched);
+    });
+
+    for (auto _ : state) {
+        auto fiber = task.run(sched);
+        sched->run_ready_tasks();
+        auto result = fiber->await();
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_DeferFiber_Async);
 
 // A chain of map stages moving a vector payload through each stage.
 static void BM_Map_VectorChain(benchmark::State& state) {

--- a/include/cask/Task.hpp
+++ b/include/cask/Task.hpp
@@ -92,7 +92,13 @@ public:
     template <typename Predicate = std::function<T()>>
     static Task<T,E> eval(Predicate&& thunk) noexcept {
         return Task<T,E>(
-            fiber::FiberOp::thunk(std::forward<Predicate>(thunk))
+            fiber::FiberOp::thunk([thunk = std::forward<Predicate>(thunk)](fiber::FiberValue& fiber_value) mutable {
+                try {
+                    fiber_value.setValue(Erased(thunk()));
+                } catch(E& error) {
+                    fiber_value.setError(Erased(error));
+                }
+            })
         );
     }
 
@@ -128,10 +134,14 @@ public:
     static Task<T,E> deferAction(Predicate&& predicate) noexcept  {
         return Task<T,E>(
             fiber::FiberOp::async([predicate = std::forward<Predicate>(predicate)](const auto& sched) {
-                return predicate(sched)->template mapBoth<Erased,Erased>(
-                    [](auto&& value) { return value; },
-                    [](auto&& error) { return error; }
-                );
+                try {
+                    return predicate(sched)->template mapBoth<Erased,Erased>(
+                        [](auto&& value) { return value; },
+                        [](auto&& error) { return error; }
+                    );
+                } catch(E& error) {
+                    return Deferred<Erased,Erased>::raiseError(Erased(error));
+                }
             })
         );
     }
@@ -154,12 +164,16 @@ public:
     static Task<T,E> deferFiber(Predicate&& predicate) noexcept  {
         return Task<T,E>(
             fiber::FiberOp::async([predicate = std::forward<Predicate>(predicate)](const auto& sched) {
-                auto fiber = predicate(sched)->template mapBoth<Erased,Erased>(
-                    [](auto&& value) { return value; },
-                    [](auto&& error) { return error; }
-                );
+                try {
+                    auto fiber = predicate(sched)->template mapBoth<Erased,Erased>(
+                        [](auto&& value) { return value; },
+                        [](auto&& error) { return error; }
+                    );
 
-                return Deferred<Erased,Erased>::forFiber(fiber);
+                    return Deferred<Erased,Erased>::forFiber(fiber);
+                } catch(E& error) {
+                    return Deferred<Erased,Erased>::raiseError(Erased(error));
+                }
             })
         );
     }

--- a/include/cask/fiber/FiberImpl.hpp
+++ b/include/cask/fiber/FiberImpl.hpp
@@ -503,7 +503,7 @@ bool FiberImpl<T,E>::evaluateOp(const std::shared_ptr<Scheduler>& sched) {
     case THUNK:
     {
         const FiberOp::ThunkData* thunk = op->data.thunkData;
-        value.setValue((*thunk)());
+        (*thunk)(value);
         op = nullptr;
     }
     break;

--- a/include/cask/fiber/FiberOp.hpp
+++ b/include/cask/fiber/FiberOp.hpp
@@ -98,7 +98,7 @@ enum FiberOpType : std::uint8_t { ASYNC, VALUE, ERROR, FLATMAP, THUNK, DELAY, RA
  * 
  *   1. `Value` represents a pure value which does not need to be computed.
  *   2. `Error` represents an errors which should halt execution.
- *   3. `Thunk` represents a lazily-evaluated method which returns a `Value`.
+ *   3. `Thunk` represents a lazily-evaluated method which writes a fiber result.
  *   4. `Async` represents an asynchronous operation.
  *   5. `FlatMap` represents a composite program which takes the results
  *      from one program (the input) and provides it to another program (
@@ -116,7 +116,7 @@ public:
     // The opType field (VALUE vs ERROR) already tells us which case it is.
     using ConstantData = Erased;
     using AsyncData = std::function<DeferredRef<Erased,Erased>(const std::shared_ptr<Scheduler>&)>;
-    using ThunkData = std::function<Erased()>;
+    using ThunkData = std::function<void(FiberValue&)>;
     using FlatMapInput = FiberOpRef;
     using FlatMapPredicate = std::function<FiberOpRef(FiberValue&&)>;
     using FlatMapData = std::pair<FlatMapInput,FlatMapPredicate>;
@@ -156,14 +156,28 @@ public:
     }
 
     template <typename Predicate, typename = std::enable_if_t<
-        std::is_convertible<
-            std::remove_reference_t<Predicate>,
-            std::function<Erased()>
-        >::value
+        std::is_invocable<std::remove_reference_t<Predicate>&>::value ||
+        std::is_invocable<std::remove_reference_t<Predicate>&,FiberValue&>::value
     >>
     static FiberOpRef thunk(Predicate&& thunk) noexcept {
         auto pool = cask::pool::global_pool();
-        auto thunk_data = pool->allocate<ThunkData>(std::forward<Predicate>(thunk));
+        auto thunk_data = pool->allocate<ThunkData>(
+            [thunk = std::forward<Predicate>(thunk)](FiberValue& fiber_value) mutable {
+                if constexpr (std::is_invocable<std::remove_reference_t<Predicate>&,FiberValue&>::value) {
+                    thunk(fiber_value);
+                } else {
+                    using Result = std::remove_cv_t<std::remove_reference_t<std::invoke_result_t<Predicate&>>>;
+
+                    if constexpr (std::is_same<Result,FiberValue>::value) {
+                        fiber_value = thunk();
+                    } else if constexpr (std::is_same<Result,Erased>::value) {
+                        fiber_value.setValue(thunk());
+                    } else {
+                        fiber_value.setValue(Erased(thunk()));
+                    }
+                }
+            }
+        );
         return FiberOpRef::adopt(pool->allocate<FiberOp>(thunk_data, pool));
     }
 

--- a/test/cask/fiber/TestFiberOp.cpp
+++ b/test/cask/fiber/TestFiberOp.cpp
@@ -55,7 +55,10 @@ TEST(FiberOp, Thunk) {
     ASSERT_EQ(op->opType, cask::fiber::THUNK);
 
     auto function = *(op->data.thunkData);
-    EXPECT_EQ(function().template get<int>(), 123);
+    cask::fiber::FiberValue value;
+    function(value);
+    ASSERT_TRUE(value.isValue());
+    EXPECT_EQ(value.underlying().template get<int>(), 123);
 }
 
 TEST(FiberOp, Delay) {

--- a/test/cask/task/TestTaskDefer.cpp
+++ b/test/cask/task/TestTaskDefer.cpp
@@ -5,6 +5,7 @@
 
 #include "gtest/gtest.h"
 #include "cask/Task.hpp"
+#include "cask/scheduler/BenchScheduler.hpp"
 
 using cask::Task;
 using cask::Scheduler;
@@ -57,4 +58,37 @@ TEST(TaskEval,EvalutesAsyncThingAsync) {
         ->await();
     
     EXPECT_EQ(result, 123);
+}
+
+TEST(TaskDeferAction, ThrownErrorBecomesAsyncFailure) {
+    auto sched = Scheduler::global();
+
+    try {
+        Task<int, std::string>::deferAction([](const auto&) -> cask::DeferredRef<int,std::string> {
+            throw std::string("broke");
+        })
+            .run(sched)
+            ->await();
+
+        FAIL() << "Expected task error to be thrown.";
+    } catch(const std::string& error) {
+        EXPECT_EQ(error, "broke");
+    }
+}
+
+TEST(TaskDeferAction, ThrownErrorSurvivesMapErrorRetype) {
+    auto sched = std::make_shared<cask::scheduler::BenchScheduler>();
+
+    auto fiber = Task<int, std::string>::deferAction([](const auto&) -> cask::DeferredRef<int,std::string> {
+            throw std::string("broke");
+        })
+        .template mapError<int>([](std::string&& error) {
+            return static_cast<int>(error.size());
+        })
+        .run(sched);
+
+    sched->run_ready_tasks();
+
+    ASSERT_TRUE(fiber->getError().has_value());
+    EXPECT_EQ(*(fiber->getError()), 5);  // NOLINT(bugprone-unchecked-optional-access)
 }

--- a/test/cask/task/TestTaskDeferFiber.cpp
+++ b/test/cask/task/TestTaskDeferFiber.cpp
@@ -53,3 +53,33 @@ TEST(TaskDeferFiber, Cancels) {
     ASSERT_TRUE(fiber->isCanceled());
 }
 
+TEST(TaskDeferFiber, ThrownError) {
+    auto sched = std::make_shared<BenchScheduler>();
+
+    auto fiber = Task<int,std::string>::deferFiber([](const auto&) -> cask::FiberRef<int,std::string> {
+            throw std::string("broke");
+        })
+        .run(sched);
+
+    sched->run_ready_tasks();
+
+    ASSERT_TRUE(fiber->getError().has_value());
+    EXPECT_EQ(*(fiber->getError()), "broke");  // NOLINT(bugprone-unchecked-optional-access)
+}
+
+TEST(TaskDeferFiber, ThrownErrorSurvivesMapErrorRetype) {
+    auto sched = std::make_shared<BenchScheduler>();
+
+    auto fiber = Task<int,std::string>::deferFiber([](const auto&) -> cask::FiberRef<int,std::string> {
+            throw std::string("broke");
+        })
+        .template mapError<int>([](std::string&& error) {
+            return static_cast<int>(error.size());
+        })
+        .run(sched);
+
+    sched->run_ready_tasks();
+
+    ASSERT_TRUE(fiber->getError().has_value());
+    EXPECT_EQ(*(fiber->getError()), 5);  // NOLINT(bugprone-unchecked-optional-access)
+}

--- a/test/cask/task/TestTaskEval.cpp
+++ b/test/cask/task/TestTaskEval.cpp
@@ -24,3 +24,41 @@ TEST(TaskEval,EvaluatesAsync) {
     
     EXPECT_EQ(result, 123);
 }
+
+TEST(TaskEval,ThrownErrorBecomesSyncFailure) {
+    auto result = Task<int, std::string>::eval([]() -> int {
+        throw std::string("broke");
+    }).runSync();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->is_right());  // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result->get_right(), "broke");  // NOLINT(bugprone-unchecked-optional-access)
+}
+
+TEST(TaskEval,ThrownErrorBecomesAsyncFailure) {
+    try {
+        Task<int, std::string>::eval([]() -> int {
+            throw std::string("broke");
+        })
+            .run(Scheduler::global())
+            ->await();
+
+        FAIL() << "Expected task error to be thrown.";
+    } catch(const std::string& error) {
+        EXPECT_EQ(error, "broke");
+    }
+}
+
+TEST(TaskEval,ThrownErrorSurvivesMapErrorRetype) {
+    auto result = Task<int, std::string>::eval([]() -> int {
+        throw std::string("broke");
+    })
+        .template mapError<int>([](std::string&& error) {
+            return static_cast<int>(error.size());
+        })
+        .runSync();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->is_right());  // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result->get_right(), 5);  // NOLINT(bugprone-unchecked-optional-access)
+}


### PR DESCRIPTION
Previously, user functions passed to Task::eval, Task::defer, Task::deferAction, and Task::deferFiber ran with no exception protection. A thrown error - even one of the task's own error type E - escaped the fiber run loop onto a scheduler thread, typically terminating the process instead of failing the task.

A naive fix (catching E in the fiber run loop) is wrong in the general case: the run loop only knows the fiber's *final* error type, but operators like mapError and failed can retype the error channel after the thunk is created. A thunk that throws std::string under a task later retyped to E=int would sail past a catch(int&).

Instead, convert exceptions at the operator boundary, where the task's original E is still statically known:

* Task::eval wraps the user thunk in try/catch(E&) at construction time, producing an error result on throw. Task::defer inherits this since it is built on eval.
* Task::deferAction and Task::deferFiber wrap their predicates the same way, converting a thrown E into a failed Deferred.
* FiberOp::ThunkData changes from std::function<Erased()> to std::function<void(FiberValue&)> so a thunk can produce either a value or an error, writing directly into the fiber's result slot with no extra temporary. FiberOp::thunk still accepts plain value-returning callables and adapts them automatically.
* The THUNK branch of the run loop is now a simple pass-through with no exception handling of its own.

Note that only exceptions of type E are converted; other exception types continue to propagate.